### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/containers/containers.go
+++ b/containers/containers.go
@@ -20,13 +20,13 @@ type Container interface {
 	Empty() bool
 	Size() int
 	Clear()
-	Values() []interface{}
+	Values() []any
 	String() string
 }
 
 // GetSortedValues returns sorted container's elements with respect to the passed comparator.
 // Does not affect the ordering of elements within the container.
-func GetSortedValues(container Container, comparator utils.Comparator) []interface{} {
+func GetSortedValues(container Container, comparator utils.Comparator) []any {
 	values := container.Values()
 	if len(values) < 2 {
 		return values

--- a/containers/containers_test.go
+++ b/containers/containers_test.go
@@ -15,7 +15,7 @@ import (
 
 // For testing purposes
 type ContainerTest struct {
-	values []interface{}
+	values []any
 }
 
 func (container ContainerTest) Empty() bool {
@@ -27,10 +27,10 @@ func (container ContainerTest) Size() int {
 }
 
 func (container ContainerTest) Clear() {
-	container.values = []interface{}{}
+	container.values = []any{}
 }
 
-func (container ContainerTest) Values() []interface{} {
+func (container ContainerTest) Values() []any {
 	return container.values
 }
 
@@ -47,7 +47,7 @@ func (container ContainerTest) String() string {
 func TestGetSortedValuesInts(t *testing.T) {
 	container := ContainerTest{}
 	GetSortedValues(container, utils.IntComparator)
-	container.values = []interface{}{5, 1, 3, 2, 4}
+	container.values = []any{5, 1, 3, 2, 4}
 	values := GetSortedValues(container, utils.IntComparator)
 	for i := 1; i < container.Size(); i++ {
 		if values[i-1].(int) > values[i].(int) {
@@ -59,7 +59,7 @@ func TestGetSortedValuesInts(t *testing.T) {
 func TestGetSortedValuesStrings(t *testing.T) {
 	container := ContainerTest{}
 	GetSortedValues(container, utils.StringComparator)
-	container.values = []interface{}{"g", "a", "d", "e", "f", "c", "b"}
+	container.values = []any{"g", "a", "d", "e", "f", "c", "b"}
 	values := GetSortedValues(container, utils.StringComparator)
 	for i := 1; i < container.Size(); i++ {
 		if values[i-1].(string) > values[i].(string) {

--- a/containers/enumerable.go
+++ b/containers/enumerable.go
@@ -7,7 +7,7 @@ package containers
 // EnumerableWithIndex provides functions for ordered containers whose values can be fetched by an index.
 type EnumerableWithIndex interface {
 	// Each calls the given function once for each element, passing that element's index and value.
-	Each(func(index int, value interface{}))
+	Each(func(index int, value any))
 
 	// Map invokes the given function once for each element and returns a
 	// container containing the values returned by the given function.
@@ -18,22 +18,22 @@ type EnumerableWithIndex interface {
 
 	// Any passes each element of the container to the given function and
 	// returns true if the function ever returns true for any element.
-	Any(func(index int, value interface{}) bool) bool
+	Any(func(index int, value any) bool) bool
 
 	// All passes each element of the container to the given function and
 	// returns true if the function returns true for all elements.
-	All(func(index int, value interface{}) bool) bool
+	All(func(index int, value any) bool) bool
 
 	// Find passes each element of the container to the given function and returns
 	// the first (index,value) for which the function is true or -1,nil otherwise
 	// if no element matches the criteria.
-	Find(func(index int, value interface{}) bool) (int, interface{})
+	Find(func(index int, value any) bool) (int, any)
 }
 
 // EnumerableWithKey provides functions for ordered containers whose values whose elements are key/value pairs.
 type EnumerableWithKey interface {
 	// Each calls the given function once for each element, passing that element's key and value.
-	Each(func(key interface{}, value interface{}))
+	Each(func(key any, value any))
 
 	// Map invokes the given function once for each element and returns a container
 	// containing the values returned by the given function as key/value pairs.
@@ -44,14 +44,14 @@ type EnumerableWithKey interface {
 
 	// Any passes each element of the container to the given function and
 	// returns true if the function ever returns true for any element.
-	Any(func(key interface{}, value interface{}) bool) bool
+	Any(func(key any, value any) bool) bool
 
 	// All passes each element of the container to the given function and
 	// returns true if the function returns true for all elements.
-	All(func(key interface{}, value interface{}) bool) bool
+	All(func(key any, value any) bool) bool
 
 	// Find passes each element of the container to the given function and returns
 	// the first (key,value) for which the function is true or nil,nil otherwise if no element
 	// matches the criteria.
-	Find(func(key interface{}, value interface{}) bool) (interface{}, interface{})
+	Find(func(key any, value any) bool) (any, any)
 }

--- a/containers/iterator.go
+++ b/containers/iterator.go
@@ -14,7 +14,7 @@ type IteratorWithIndex interface {
 
 	// Value returns the current element's value.
 	// Does not modify the state of the iterator.
-	Value() interface{}
+	Value() any
 
 	// Index returns the current element's index.
 	// Does not modify the state of the iterator.
@@ -33,7 +33,7 @@ type IteratorWithIndex interface {
 	// passed function, and returns true if there was a next element in the container.
 	// If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 	// Modifies the state of the iterator.
-	NextTo(func(index int, value interface{}) bool) bool
+	NextTo(func(index int, value any) bool) bool
 }
 
 // IteratorWithKey is a stateful iterator for ordered containers whose elements are key value pairs.
@@ -46,11 +46,11 @@ type IteratorWithKey interface {
 
 	// Value returns the current element's value.
 	// Does not modify the state of the iterator.
-	Value() interface{}
+	Value() any
 
 	// Key returns the current element's key.
 	// Does not modify the state of the iterator.
-	Key() interface{}
+	Key() any
 
 	// Begin resets the iterator to its initial state (one-before-first)
 	// Call Next() to fetch the first element if any.
@@ -65,14 +65,14 @@ type IteratorWithKey interface {
 	// passed function, and returns true if there was a next element in the container.
 	// If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 	// Modifies the state of the iterator.
-	NextTo(func(key interface{}, value interface{}) bool) bool
+	NextTo(func(key any, value any) bool) bool
 }
 
 // ReverseIteratorWithIndex is stateful iterator for ordered containers whose values can be fetched by an index.
 //
 // Essentially it is the same as IteratorWithIndex, but provides additional:
 //
-// Prev() function to enable traversal in reverse
+// # Prev() function to enable traversal in reverse
 //
 // Last() function to move the iterator to the last element.
 //
@@ -96,7 +96,7 @@ type ReverseIteratorWithIndex interface {
 	// passed function, and returns true if there was a next element in the container.
 	// If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 	// Modifies the state of the iterator.
-	PrevTo(func(index int, value interface{}) bool) bool
+	PrevTo(func(index int, value any) bool) bool
 
 	IteratorWithIndex
 }
@@ -105,7 +105,7 @@ type ReverseIteratorWithIndex interface {
 //
 // Essentially it is the same as IteratorWithKey, but provides additional:
 //
-// Prev() function to enable traversal in reverse
+// # Prev() function to enable traversal in reverse
 //
 // Last() function to move the iterator to the last element.
 type ReverseIteratorWithKey interface {
@@ -127,7 +127,7 @@ type ReverseIteratorWithKey interface {
 	// passed function, and returns true if there was a next element in the container.
 	// If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 	// Modifies the state of the iterator.
-	PrevTo(func(key interface{}, value interface{}) bool) bool
+	PrevTo(func(key any, value any) bool) bool
 
 	IteratorWithKey
 }

--- a/examples/binaryheap/binaryheap.go
+++ b/examples/binaryheap/binaryheap.go
@@ -29,7 +29,7 @@ func main() {
 	heap.Size()                               // 0
 
 	// Max-heap
-	inverseIntComparator := func(a, b interface{}) int {
+	inverseIntComparator := func(a, b any) int {
 		return -utils.IntComparator(a, b)
 	}
 	heap = binaryheap.NewWith(inverseIntComparator) // empty (min-heap)

--- a/examples/customcomparator/customcomparator.go
+++ b/examples/customcomparator/customcomparator.go
@@ -16,7 +16,7 @@ type User struct {
 }
 
 // Comparator function (sort by IDs)
-func byID(a, b interface{}) int {
+func byID(a, b any) int {
 
 	// Type assertion, program will panic if this is not respected
 	c1 := a.(User)

--- a/examples/enumerablewithindex/enumerablewithindex.go
+++ b/examples/enumerablewithindex/enumerablewithindex.go
@@ -11,7 +11,7 @@ import (
 
 func printSet(txt string, set *treeset.Set) {
 	fmt.Print(txt, "[ ")
-	set.Each(func(index int, value interface{}) {
+	set.Each(func(index int, value any) {
 		fmt.Print(value, " ")
 	})
 	fmt.Println("]")
@@ -23,36 +23,36 @@ func main() {
 	set.Add(2, 3, 4, 2, 5, 6, 7, 8)
 	printSet("Initial", set) // [ 2 3 4 5 6 7 8 ]
 
-	even := set.Select(func(index int, value interface{}) bool {
+	even := set.Select(func(index int, value any) bool {
 		return value.(int)%2 == 0
 	})
 	printSet("Even numbers", even) // [ 2 4 6 8 ]
 
-	foundIndex, foundValue := set.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue := set.Find(func(index int, value any) bool {
 		return value.(int)%2 == 0 && value.(int)%3 == 0
 	})
 	if foundIndex != -1 {
 		fmt.Println("Number divisible by 2 and 3 found is", foundValue, "at index", foundIndex) // value: 6, index: 4
 	}
 
-	square := set.Map(func(index int, value interface{}) interface{} {
+	square := set.Map(func(index int, value any) any {
 		return value.(int) * value.(int)
 	})
 	printSet("Numbers squared", square) // [ 4 9 16 25 36 49 64 ]
 
-	bigger := set.Any(func(index int, value interface{}) bool {
+	bigger := set.Any(func(index int, value any) bool {
 		return value.(int) > 5
 	})
 	fmt.Println("Set contains a number bigger than 5 is ", bigger) // true
 
-	positive := set.All(func(index int, value interface{}) bool {
+	positive := set.All(func(index int, value any) bool {
 		return value.(int) > 0
 	})
 	fmt.Println("All numbers are positive is", positive) // true
 
-	evenNumbersSquared := set.Select(func(index int, value interface{}) bool {
+	evenNumbersSquared := set.Select(func(index int, value any) bool {
 		return value.(int)%2 == 0
-	}).Map(func(index int, value interface{}) interface{} {
+	}).Map(func(index int, value any) any {
 		return value.(int) * value.(int)
 	})
 	printSet("Chaining", evenNumbersSquared) // [ 4 16 36 64 ]

--- a/examples/enumerablewithkey/enumerablewithkey.go
+++ b/examples/enumerablewithkey/enumerablewithkey.go
@@ -11,7 +11,7 @@ import (
 
 func printMap(txt string, m *treemap.Map) {
 	fmt.Print(txt, " { ")
-	m.Each(func(key interface{}, value interface{}) {
+	m.Each(func(key any, value any) {
 		fmt.Print(key, ":", value, " ")
 	})
 	fmt.Println("}")
@@ -29,36 +29,36 @@ func main() {
 	m.Put("a", 1)
 	printMap("Initial", m) // { a:1 b:2 c:3 d:4 e:5 f:6 g:7 }
 
-	even := m.Select(func(key interface{}, value interface{}) bool {
+	even := m.Select(func(key any, value any) bool {
 		return value.(int)%2 == 0
 	})
 	printMap("Elements with even values", even) // { b:2 d:4 f:6 }
 
-	foundKey, foundValue := m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue := m.Find(func(key any, value any) bool {
 		return value.(int)%2 == 0 && value.(int)%3 == 0
 	})
 	if foundKey != nil {
 		fmt.Println("Element with value divisible by 2 and 3 found is", foundValue, "with key", foundKey) // value: 6, index: 4
 	}
 
-	square := m.Map(func(key interface{}, value interface{}) (interface{}, interface{}) {
+	square := m.Map(func(key any, value any) (any, any) {
 		return key.(string) + key.(string), value.(int) * value.(int)
 	})
 	printMap("Elements' values squared and letters duplicated", square) // { aa:1 bb:4 cc:9 dd:16 ee:25 ff:36 gg:49 }
 
-	bigger := m.Any(func(key interface{}, value interface{}) bool {
+	bigger := m.Any(func(key any, value any) bool {
 		return value.(int) > 5
 	})
 	fmt.Println("Map contains element whose value is bigger than 5 is", bigger) // true
 
-	positive := m.All(func(key interface{}, value interface{}) bool {
+	positive := m.All(func(key any, value any) bool {
 		return value.(int) > 0
 	})
 	fmt.Println("All map's elements have positive values is", positive) // true
 
-	evenNumbersSquared := m.Select(func(key interface{}, value interface{}) bool {
+	evenNumbersSquared := m.Select(func(key any, value any) bool {
 		return value.(int)%2 == 0
-	}).Map(func(key interface{}, value interface{}) (interface{}, interface{}) {
+	}).Map(func(key any, value any) (any, any) {
 		return key, value.(int) * value.(int)
 	})
 	printMap("Chaining", evenNumbersSquared) // { b:4 d:16 f:36 }

--- a/examples/godsort/godsort.go
+++ b/examples/godsort/godsort.go
@@ -8,7 +8,7 @@ import "github.com/emirpasic/gods/utils"
 
 // SortExample to demonstrate basic usage of basic sort
 func main() {
-	strings := []interface{}{}                  // []
+	strings := []any{}                          // []
 	strings = append(strings, "d")              // ["d"]
 	strings = append(strings, "a")              // ["d","a"]
 	strings = append(strings, "b")              // ["d","a",b"

--- a/examples/iteratorwithindex/iteratorwithindex.go
+++ b/examples/iteratorwithindex/iteratorwithindex.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	// Seek element starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 

--- a/examples/iteratorwithkey/iteratorwithkey.go
+++ b/examples/iteratorwithkey/iteratorwithkey.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Seek key-value pair whose value starts with "b"
-	seek := func(key interface{}, value interface{}) bool {
+	seek := func(key any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 

--- a/examples/priorityqueue/priorityqueue.go
+++ b/examples/priorityqueue/priorityqueue.go
@@ -16,7 +16,7 @@ type Element struct {
 }
 
 // Comparator function (sort by element's priority value in descending order)
-func byPriority(a, b interface{}) int {
+func byPriority(a, b any) int {
 	priorityA := a.(Element).priority
 	priorityB := b.(Element).priority
 	return -utils.IntComparator(priorityA, priorityB) // "-" descending order

--- a/examples/redblacktreeextended/redblacktreeextended.go
+++ b/examples/redblacktreeextended/redblacktreeextended.go
@@ -15,7 +15,7 @@ type RedBlackTreeExtended struct {
 }
 
 // GetMin gets the min value and flag if found
-func (tree *RedBlackTreeExtended) GetMin() (value interface{}, found bool) {
+func (tree *RedBlackTreeExtended) GetMin() (value any, found bool) {
 	node, found := tree.getMinFromNode(tree.Root)
 	if node != nil {
 		return node.Value, found
@@ -24,7 +24,7 @@ func (tree *RedBlackTreeExtended) GetMin() (value interface{}, found bool) {
 }
 
 // GetMax gets the max value and flag if found
-func (tree *RedBlackTreeExtended) GetMax() (value interface{}, found bool) {
+func (tree *RedBlackTreeExtended) GetMax() (value any, found bool) {
 	node, found := tree.getMaxFromNode(tree.Root)
 	if node != nil {
 		return node.Value, found
@@ -33,7 +33,7 @@ func (tree *RedBlackTreeExtended) GetMax() (value interface{}, found bool) {
 }
 
 // RemoveMin removes the min value and flag if found
-func (tree *RedBlackTreeExtended) RemoveMin() (value interface{}, deleted bool) {
+func (tree *RedBlackTreeExtended) RemoveMin() (value any, deleted bool) {
 	node, found := tree.getMinFromNode(tree.Root)
 	if found {
 		tree.Remove(node.Key)
@@ -43,7 +43,7 @@ func (tree *RedBlackTreeExtended) RemoveMin() (value interface{}, deleted bool) 
 }
 
 // RemoveMax removes the max value and flag if found
-func (tree *RedBlackTreeExtended) RemoveMax() (value interface{}, deleted bool) {
+func (tree *RedBlackTreeExtended) RemoveMax() (value any, deleted bool) {
 	node, found := tree.getMaxFromNode(tree.Root)
 	if found {
 		tree.Remove(node.Key)

--- a/lists/arraylist/arraylist.go
+++ b/lists/arraylist/arraylist.go
@@ -22,7 +22,7 @@ var _ lists.List = (*List)(nil)
 
 // List holds the elements in a slice
 type List struct {
-	elements []interface{}
+	elements []any
 	size     int
 }
 
@@ -32,7 +32,7 @@ const (
 )
 
 // New instantiates a new list and adds the passed values, if any, to the list
-func New(values ...interface{}) *List {
+func New(values ...any) *List {
 	list := &List{}
 	if len(values) > 0 {
 		list.Add(values...)
@@ -41,7 +41,7 @@ func New(values ...interface{}) *List {
 }
 
 // Add appends a value at the end of the list
-func (list *List) Add(values ...interface{}) {
+func (list *List) Add(values ...any) {
 	list.growBy(len(values))
 	for _, value := range values {
 		list.elements[list.size] = value
@@ -51,7 +51,7 @@ func (list *List) Add(values ...interface{}) {
 
 // Get returns the element at index.
 // Second return parameter is true if index is within bounds of the array and array is not empty, otherwise false.
-func (list *List) Get(index int) (interface{}, bool) {
+func (list *List) Get(index int) (any, bool) {
 
 	if !list.withinRange(index) {
 		return nil, false
@@ -78,7 +78,7 @@ func (list *List) Remove(index int) {
 // All elements have to be present in the set for the method to return true.
 // Performance time complexity of n^2.
 // Returns true if no arguments are passed at all, i.e. set is always super-set of empty set.
-func (list *List) Contains(values ...interface{}) bool {
+func (list *List) Contains(values ...any) bool {
 
 	for _, searchValue := range values {
 		found := false
@@ -96,14 +96,14 @@ func (list *List) Contains(values ...interface{}) bool {
 }
 
 // Values returns all elements in the list.
-func (list *List) Values() []interface{} {
-	newElements := make([]interface{}, list.size, list.size)
+func (list *List) Values() []any {
+	newElements := make([]any, list.size, list.size)
 	copy(newElements, list.elements[:list.size])
 	return newElements
 }
 
-//IndexOf returns index of provided element
-func (list *List) IndexOf(value interface{}) int {
+// IndexOf returns index of provided element
+func (list *List) IndexOf(value any) int {
 	if list.size == 0 {
 		return -1
 	}
@@ -128,7 +128,7 @@ func (list *List) Size() int {
 // Clear removes all elements from the list.
 func (list *List) Clear() {
 	list.size = 0
-	list.elements = []interface{}{}
+	list.elements = []any{}
 }
 
 // Sort sorts values (in-place) using.
@@ -149,7 +149,7 @@ func (list *List) Swap(i, j int) {
 // Insert inserts values at specified index position shifting the value at that position (if any) and any subsequent elements to the right.
 // Does not do anything if position is negative or bigger than list's size
 // Note: position equal to list's size is valid, i.e. append.
-func (list *List) Insert(index int, values ...interface{}) {
+func (list *List) Insert(index int, values ...any) {
 
 	if !list.withinRange(index) {
 		// Append
@@ -169,7 +169,7 @@ func (list *List) Insert(index int, values ...interface{}) {
 // Set the value at specified index
 // Does not do anything if position is negative or bigger than list's size
 // Note: position equal to list's size is valid, i.e. append.
-func (list *List) Set(index int, value interface{}) {
+func (list *List) Set(index int, value any) {
 
 	if !list.withinRange(index) {
 		// Append
@@ -199,7 +199,7 @@ func (list *List) withinRange(index int) bool {
 }
 
 func (list *List) resize(cap int) {
-	newElements := make([]interface{}, cap, cap)
+	newElements := make([]any, cap, cap)
 	copy(newElements, list.elements)
 	list.elements = newElements
 }

--- a/lists/arraylist/arraylist_test.go
+++ b/lists/arraylist/arraylist_test.go
@@ -232,7 +232,7 @@ func TestListSet(t *testing.T) {
 func TestListEach(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	list.Each(func(index int, value interface{}) {
+	list.Each(func(index int, value any) {
 		switch index {
 		case 0:
 			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
@@ -255,7 +255,7 @@ func TestListEach(t *testing.T) {
 func TestListMap(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	mappedList := list.Map(func(index int, value interface{}) interface{} {
+	mappedList := list.Map(func(index int, value any) any {
 		return "mapped: " + value.(string)
 	})
 	if actualValue, _ := mappedList.Get(0); actualValue != "mapped: a" {
@@ -275,7 +275,7 @@ func TestListMap(t *testing.T) {
 func TestListSelect(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	selectedList := list.Select(func(index int, value interface{}) bool {
+	selectedList := list.Select(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if actualValue, _ := selectedList.Get(0); actualValue != "a" {
@@ -292,13 +292,13 @@ func TestListSelect(t *testing.T) {
 func TestListAny(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	any := list.Any(func(index int, value interface{}) bool {
+	any := list.Any(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = list.Any(func(index int, value interface{}) bool {
+	any = list.Any(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if any != false {
@@ -308,13 +308,13 @@ func TestListAny(t *testing.T) {
 func TestListAll(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	all := list.All(func(index int, value interface{}) bool {
+	all := list.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = list.All(func(index int, value interface{}) bool {
+	all = list.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if all != false {
@@ -324,13 +324,13 @@ func TestListAll(t *testing.T) {
 func TestListFind(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	foundIndex, foundValue := list.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue := list.Find(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if foundValue != "c" || foundIndex != 2 {
 		t.Errorf("Got %v at %v expected %v at %v", foundValue, foundIndex, "c", 2)
 	}
-	foundIndex, foundValue = list.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue = list.Find(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if foundValue != nil || foundIndex != -1 {
@@ -340,9 +340,9 @@ func TestListFind(t *testing.T) {
 func TestListChaining(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	chainedList := list.Select(func(index int, value interface{}) bool {
+	chainedList := list.Select(func(index int, value any) bool {
 		return value.(string) > "a"
-	}).Map(func(index int, value interface{}) interface{} {
+	}).Map(func(index int, value any) any {
 		return value.(string) + value.(string)
 	})
 	if chainedList.Size() != 2 {
@@ -507,7 +507,7 @@ func TestListIteratorLast(t *testing.T) {
 
 func TestListIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -556,7 +556,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 func TestListIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -630,7 +630,7 @@ func TestListSerialization(t *testing.T) {
 	err = list.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", list})
+	bytes, err = json.Marshal([]any{"a", "b", "c", list})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/lists/arraylist/enumerable.go
+++ b/lists/arraylist/enumerable.go
@@ -10,7 +10,7 @@ import "github.com/emirpasic/gods/containers"
 var _ containers.EnumerableWithIndex = (*List)(nil)
 
 // Each calls the given function once for each element, passing that element's index and value.
-func (list *List) Each(f func(index int, value interface{})) {
+func (list *List) Each(f func(index int, value any)) {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		f(iterator.Index(), iterator.Value())
@@ -19,7 +19,7 @@ func (list *List) Each(f func(index int, value interface{})) {
 
 // Map invokes the given function once for each element and returns a
 // container containing the values returned by the given function.
-func (list *List) Map(f func(index int, value interface{}) interface{}) *List {
+func (list *List) Map(f func(index int, value any) any) *List {
 	newList := &List{}
 	iterator := list.Iterator()
 	for iterator.Next() {
@@ -29,7 +29,7 @@ func (list *List) Map(f func(index int, value interface{}) interface{}) *List {
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (list *List) Select(f func(index int, value interface{}) bool) *List {
+func (list *List) Select(f func(index int, value any) bool) *List {
 	newList := &List{}
 	iterator := list.Iterator()
 	for iterator.Next() {
@@ -42,7 +42,7 @@ func (list *List) Select(f func(index int, value interface{}) bool) *List {
 
 // Any passes each element of the collection to the given function and
 // returns true if the function ever returns true for any element.
-func (list *List) Any(f func(index int, value interface{}) bool) bool {
+func (list *List) Any(f func(index int, value any) bool) bool {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {
@@ -54,7 +54,7 @@ func (list *List) Any(f func(index int, value interface{}) bool) bool {
 
 // All passes each element of the collection to the given function and
 // returns true if the function returns true for all elements.
-func (list *List) All(f func(index int, value interface{}) bool) bool {
+func (list *List) All(f func(index int, value any) bool) bool {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Index(), iterator.Value()) {
@@ -67,7 +67,7 @@ func (list *List) All(f func(index int, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (index,value) for which the function is true or -1,nil otherwise
 // if no element matches the criteria.
-func (list *List) Find(f func(index int, value interface{}) bool) (int, interface{}) {
+func (list *List) Find(f func(index int, value any) bool) (int, any) {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {

--- a/lists/arraylist/iterator.go
+++ b/lists/arraylist/iterator.go
@@ -43,7 +43,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.list.elements[iterator.index]
 }
 
@@ -85,7 +85,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -99,7 +99,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/lists/doublylinkedlist/doublylinkedlist.go
+++ b/lists/doublylinkedlist/doublylinkedlist.go
@@ -28,13 +28,13 @@ type List struct {
 }
 
 type element struct {
-	value interface{}
+	value any
 	prev  *element
 	next  *element
 }
 
 // New instantiates a new list and adds the passed values, if any, to the list
-func New(values ...interface{}) *List {
+func New(values ...any) *List {
 	list := &List{}
 	if len(values) > 0 {
 		list.Add(values...)
@@ -43,7 +43,7 @@ func New(values ...interface{}) *List {
 }
 
 // Add appends a value (one or more) at the end of the list (same as Append())
-func (list *List) Add(values ...interface{}) {
+func (list *List) Add(values ...any) {
 	for _, value := range values {
 		newElement := &element{value: value, prev: list.last}
 		if list.size == 0 {
@@ -58,12 +58,12 @@ func (list *List) Add(values ...interface{}) {
 }
 
 // Append appends a value (one or more) at the end of the list (same as Add())
-func (list *List) Append(values ...interface{}) {
+func (list *List) Append(values ...any) {
 	list.Add(values...)
 }
 
 // Prepend prepends a values (or more)
-func (list *List) Prepend(values ...interface{}) {
+func (list *List) Prepend(values ...any) {
 	// in reverse to keep passed order i.e. ["c","d"] -> Prepend(["a","b"]) -> ["a","b","c",d"]
 	for v := len(values) - 1; v >= 0; v-- {
 		newElement := &element{value: values[v], next: list.first}
@@ -80,7 +80,7 @@ func (list *List) Prepend(values ...interface{}) {
 
 // Get returns the element at index.
 // Second return parameter is true if index is within bounds of the array and array is not empty, otherwise false.
-func (list *List) Get(index int) (interface{}, bool) {
+func (list *List) Get(index int) (any, bool) {
 
 	if !list.withinRange(index) {
 		return nil, false
@@ -145,7 +145,7 @@ func (list *List) Remove(index int) {
 // All values have to be present in the set for the method to return true.
 // Performance time complexity of n^2.
 // Returns true if no arguments are passed at all, i.e. set is always super-set of empty set.
-func (list *List) Contains(values ...interface{}) bool {
+func (list *List) Contains(values ...any) bool {
 
 	if len(values) == 0 {
 		return true
@@ -169,16 +169,16 @@ func (list *List) Contains(values ...interface{}) bool {
 }
 
 // Values returns all elements in the list.
-func (list *List) Values() []interface{} {
-	values := make([]interface{}, list.size, list.size)
+func (list *List) Values() []any {
+	values := make([]any, list.size, list.size)
 	for e, element := 0, list.first; element != nil; e, element = e+1, element.next {
 		values[e] = element.value
 	}
 	return values
 }
 
-//IndexOf returns index of provided element
-func (list *List) IndexOf(value interface{}) int {
+// IndexOf returns index of provided element
+func (list *List) IndexOf(value any) int {
 	if list.size == 0 {
 		return -1
 	}
@@ -242,7 +242,7 @@ func (list *List) Swap(i, j int) {
 // Insert inserts values at specified index position shifting the value at that position (if any) and any subsequent elements to the right.
 // Does not do anything if position is negative or bigger than list's size
 // Note: position equal to list's size is valid, i.e. append.
-func (list *List) Insert(index int, values ...interface{}) {
+func (list *List) Insert(index int, values ...any) {
 
 	if !list.withinRange(index) {
 		// Append
@@ -299,7 +299,7 @@ func (list *List) Insert(index int, values ...interface{}) {
 // Set value at specified index position
 // Does not do anything if position is negative or bigger than list's size
 // Note: position equal to list's size is valid, i.e. append.
-func (list *List) Set(index int, value interface{}) {
+func (list *List) Set(index int, value any) {
 
 	if !list.withinRange(index) {
 		// Append

--- a/lists/doublylinkedlist/doublylinkedlist_test.go
+++ b/lists/doublylinkedlist/doublylinkedlist_test.go
@@ -257,7 +257,7 @@ func TestListSet(t *testing.T) {
 func TestListEach(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	list.Each(func(index int, value interface{}) {
+	list.Each(func(index int, value any) {
 		switch index {
 		case 0:
 			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
@@ -280,7 +280,7 @@ func TestListEach(t *testing.T) {
 func TestListMap(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	mappedList := list.Map(func(index int, value interface{}) interface{} {
+	mappedList := list.Map(func(index int, value any) any {
 		return "mapped: " + value.(string)
 	})
 	if actualValue, _ := mappedList.Get(0); actualValue != "mapped: a" {
@@ -300,7 +300,7 @@ func TestListMap(t *testing.T) {
 func TestListSelect(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	selectedList := list.Select(func(index int, value interface{}) bool {
+	selectedList := list.Select(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if actualValue, _ := selectedList.Get(0); actualValue != "a" {
@@ -317,13 +317,13 @@ func TestListSelect(t *testing.T) {
 func TestListAny(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	any := list.Any(func(index int, value interface{}) bool {
+	any := list.Any(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = list.Any(func(index int, value interface{}) bool {
+	any = list.Any(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if any != false {
@@ -333,13 +333,13 @@ func TestListAny(t *testing.T) {
 func TestListAll(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	all := list.All(func(index int, value interface{}) bool {
+	all := list.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = list.All(func(index int, value interface{}) bool {
+	all = list.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if all != false {
@@ -349,13 +349,13 @@ func TestListAll(t *testing.T) {
 func TestListFind(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	foundIndex, foundValue := list.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue := list.Find(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if foundValue != "c" || foundIndex != 2 {
 		t.Errorf("Got %v at %v expected %v at %v", foundValue, foundIndex, "c", 2)
 	}
-	foundIndex, foundValue = list.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue = list.Find(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if foundValue != nil || foundIndex != -1 {
@@ -365,9 +365,9 @@ func TestListFind(t *testing.T) {
 func TestListChaining(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	chainedList := list.Select(func(index int, value interface{}) bool {
+	chainedList := list.Select(func(index int, value any) bool {
 		return value.(string) > "a"
-	}).Map(func(index int, value interface{}) interface{} {
+	}).Map(func(index int, value any) any {
 		return value.(string) + value.(string)
 	})
 	if chainedList.Size() != 2 {
@@ -532,7 +532,7 @@ func TestListIteratorLast(t *testing.T) {
 
 func TestListIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -581,7 +581,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 func TestListIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -655,7 +655,7 @@ func TestListSerialization(t *testing.T) {
 	err = list.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", list})
+	bytes, err = json.Marshal([]any{"a", "b", "c", list})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/lists/doublylinkedlist/enumerable.go
+++ b/lists/doublylinkedlist/enumerable.go
@@ -10,7 +10,7 @@ import "github.com/emirpasic/gods/containers"
 var _ containers.EnumerableWithIndex = (*List)(nil)
 
 // Each calls the given function once for each element, passing that element's index and value.
-func (list *List) Each(f func(index int, value interface{})) {
+func (list *List) Each(f func(index int, value any)) {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		f(iterator.Index(), iterator.Value())
@@ -19,7 +19,7 @@ func (list *List) Each(f func(index int, value interface{})) {
 
 // Map invokes the given function once for each element and returns a
 // container containing the values returned by the given function.
-func (list *List) Map(f func(index int, value interface{}) interface{}) *List {
+func (list *List) Map(f func(index int, value any) any) *List {
 	newList := &List{}
 	iterator := list.Iterator()
 	for iterator.Next() {
@@ -29,7 +29,7 @@ func (list *List) Map(f func(index int, value interface{}) interface{}) *List {
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (list *List) Select(f func(index int, value interface{}) bool) *List {
+func (list *List) Select(f func(index int, value any) bool) *List {
 	newList := &List{}
 	iterator := list.Iterator()
 	for iterator.Next() {
@@ -42,7 +42,7 @@ func (list *List) Select(f func(index int, value interface{}) bool) *List {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (list *List) Any(f func(index int, value interface{}) bool) bool {
+func (list *List) Any(f func(index int, value any) bool) bool {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {
@@ -54,7 +54,7 @@ func (list *List) Any(f func(index int, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (list *List) All(f func(index int, value interface{}) bool) bool {
+func (list *List) All(f func(index int, value any) bool) bool {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Index(), iterator.Value()) {
@@ -67,7 +67,7 @@ func (list *List) All(f func(index int, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (index,value) for which the function is true or -1,nil otherwise
 // if no element matches the criteria.
-func (list *List) Find(f func(index int, value interface{}) bool) (index int, value interface{}) {
+func (list *List) Find(f func(index int, value any) bool) (index int, value any) {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {

--- a/lists/doublylinkedlist/iterator.go
+++ b/lists/doublylinkedlist/iterator.go
@@ -62,7 +62,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.element.value
 }
 
@@ -106,7 +106,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -120,7 +120,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/lists/doublylinkedlist/serialization.go
+++ b/lists/doublylinkedlist/serialization.go
@@ -20,7 +20,7 @@ func (list *List) ToJSON() ([]byte, error) {
 
 // FromJSON populates list's elements from the input JSON representation.
 func (list *List) FromJSON(data []byte) error {
-	elements := []interface{}{}
+	elements := []any{}
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		list.Clear()

--- a/lists/lists.go
+++ b/lists/lists.go
@@ -16,14 +16,14 @@ import (
 
 // List interface that all lists implement
 type List interface {
-	Get(index int) (interface{}, bool)
+	Get(index int) (any, bool)
 	Remove(index int)
-	Add(values ...interface{})
-	Contains(values ...interface{}) bool
+	Add(values ...any)
+	Contains(values ...any) bool
 	Sort(comparator utils.Comparator)
 	Swap(index1, index2 int)
-	Insert(index int, values ...interface{})
-	Set(index int, value interface{})
+	Insert(index int, values ...any)
+	Set(index int, value any)
 
 	containers.Container
 	// Empty() bool

--- a/lists/singlylinkedlist/enumerable.go
+++ b/lists/singlylinkedlist/enumerable.go
@@ -10,7 +10,7 @@ import "github.com/emirpasic/gods/containers"
 var _ containers.EnumerableWithIndex = (*List)(nil)
 
 // Each calls the given function once for each element, passing that element's index and value.
-func (list *List) Each(f func(index int, value interface{})) {
+func (list *List) Each(f func(index int, value any)) {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		f(iterator.Index(), iterator.Value())
@@ -19,7 +19,7 @@ func (list *List) Each(f func(index int, value interface{})) {
 
 // Map invokes the given function once for each element and returns a
 // container containing the values returned by the given function.
-func (list *List) Map(f func(index int, value interface{}) interface{}) *List {
+func (list *List) Map(f func(index int, value any) any) *List {
 	newList := &List{}
 	iterator := list.Iterator()
 	for iterator.Next() {
@@ -29,7 +29,7 @@ func (list *List) Map(f func(index int, value interface{}) interface{}) *List {
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (list *List) Select(f func(index int, value interface{}) bool) *List {
+func (list *List) Select(f func(index int, value any) bool) *List {
 	newList := &List{}
 	iterator := list.Iterator()
 	for iterator.Next() {
@@ -42,7 +42,7 @@ func (list *List) Select(f func(index int, value interface{}) bool) *List {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (list *List) Any(f func(index int, value interface{}) bool) bool {
+func (list *List) Any(f func(index int, value any) bool) bool {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {
@@ -54,7 +54,7 @@ func (list *List) Any(f func(index int, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (list *List) All(f func(index int, value interface{}) bool) bool {
+func (list *List) All(f func(index int, value any) bool) bool {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Index(), iterator.Value()) {
@@ -67,7 +67,7 @@ func (list *List) All(f func(index int, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (index,value) for which the function is true or -1,nil otherwise
 // if no element matches the criteria.
-func (list *List) Find(f func(index int, value interface{}) bool) (index int, value interface{}) {
+func (list *List) Find(f func(index int, value any) bool) (index int, value any) {
 	iterator := list.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {

--- a/lists/singlylinkedlist/iterator.go
+++ b/lists/singlylinkedlist/iterator.go
@@ -43,7 +43,7 @@ func (iterator *Iterator) Next() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.element.value
 }
 
@@ -72,7 +72,7 @@ func (iterator *Iterator) First() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/lists/singlylinkedlist/serialization.go
+++ b/lists/singlylinkedlist/serialization.go
@@ -20,7 +20,7 @@ func (list *List) ToJSON() ([]byte, error) {
 
 // FromJSON populates list's elements from the input JSON representation.
 func (list *List) FromJSON(data []byte) error {
-	elements := []interface{}{}
+	elements := []any{}
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		list.Clear()

--- a/lists/singlylinkedlist/singlylinkedlist.go
+++ b/lists/singlylinkedlist/singlylinkedlist.go
@@ -28,12 +28,12 @@ type List struct {
 }
 
 type element struct {
-	value interface{}
+	value any
 	next  *element
 }
 
 // New instantiates a new list and adds the passed values, if any, to the list
-func New(values ...interface{}) *List {
+func New(values ...any) *List {
 	list := &List{}
 	if len(values) > 0 {
 		list.Add(values...)
@@ -42,7 +42,7 @@ func New(values ...interface{}) *List {
 }
 
 // Add appends a value (one or more) at the end of the list (same as Append())
-func (list *List) Add(values ...interface{}) {
+func (list *List) Add(values ...any) {
 	for _, value := range values {
 		newElement := &element{value: value}
 		if list.size == 0 {
@@ -57,12 +57,12 @@ func (list *List) Add(values ...interface{}) {
 }
 
 // Append appends a value (one or more) at the end of the list (same as Add())
-func (list *List) Append(values ...interface{}) {
+func (list *List) Append(values ...any) {
 	list.Add(values...)
 }
 
 // Prepend prepends a values (or more)
-func (list *List) Prepend(values ...interface{}) {
+func (list *List) Prepend(values ...any) {
 	// in reverse to keep passed order i.e. ["c","d"] -> Prepend(["a","b"]) -> ["a","b","c",d"]
 	for v := len(values) - 1; v >= 0; v-- {
 		newElement := &element{value: values[v], next: list.first}
@@ -76,7 +76,7 @@ func (list *List) Prepend(values ...interface{}) {
 
 // Get returns the element at index.
 // Second return parameter is true if index is within bounds of the array and array is not empty, otherwise false.
-func (list *List) Get(index int) (interface{}, bool) {
+func (list *List) Get(index int) (any, bool) {
 
 	if !list.withinRange(index) {
 		return nil, false
@@ -126,7 +126,7 @@ func (list *List) Remove(index int) {
 // All values have to be present in the set for the method to return true.
 // Performance time complexity of n^2.
 // Returns true if no arguments are passed at all, i.e. set is always super-set of empty set.
-func (list *List) Contains(values ...interface{}) bool {
+func (list *List) Contains(values ...any) bool {
 
 	if len(values) == 0 {
 		return true
@@ -150,16 +150,16 @@ func (list *List) Contains(values ...interface{}) bool {
 }
 
 // Values returns all elements in the list.
-func (list *List) Values() []interface{} {
-	values := make([]interface{}, list.size, list.size)
+func (list *List) Values() []any {
+	values := make([]any, list.size, list.size)
 	for e, element := 0, list.first; element != nil; e, element = e+1, element.next {
 		values[e] = element.value
 	}
 	return values
 }
 
-//IndexOf returns index of provided element
-func (list *List) IndexOf(value interface{}) int {
+// IndexOf returns index of provided element
+func (list *List) IndexOf(value any) int {
 	if list.size == 0 {
 		return -1
 	}
@@ -223,7 +223,7 @@ func (list *List) Swap(i, j int) {
 // Insert inserts values at specified index position shifting the value at that position (if any) and any subsequent elements to the right.
 // Does not do anything if position is negative or bigger than list's size
 // Note: position equal to list's size is valid, i.e. append.
-func (list *List) Insert(index int, values ...interface{}) {
+func (list *List) Insert(index int, values ...any) {
 
 	if !list.withinRange(index) {
 		// Append
@@ -267,7 +267,7 @@ func (list *List) Insert(index int, values ...interface{}) {
 // Set value at specified index
 // Does not do anything if position is negative or bigger than list's size
 // Note: position equal to list's size is valid, i.e. append.
-func (list *List) Set(index int, value interface{}) {
+func (list *List) Set(index int, value any) {
 
 	if !list.withinRange(index) {
 		// Append

--- a/lists/singlylinkedlist/singlylinkedlist_test.go
+++ b/lists/singlylinkedlist/singlylinkedlist_test.go
@@ -252,7 +252,7 @@ func TestListSet(t *testing.T) {
 func TestListEach(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	list.Each(func(index int, value interface{}) {
+	list.Each(func(index int, value any) {
 		switch index {
 		case 0:
 			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
@@ -275,7 +275,7 @@ func TestListEach(t *testing.T) {
 func TestListMap(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	mappedList := list.Map(func(index int, value interface{}) interface{} {
+	mappedList := list.Map(func(index int, value any) any {
 		return "mapped: " + value.(string)
 	})
 	if actualValue, _ := mappedList.Get(0); actualValue != "mapped: a" {
@@ -295,7 +295,7 @@ func TestListMap(t *testing.T) {
 func TestListSelect(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	selectedList := list.Select(func(index int, value interface{}) bool {
+	selectedList := list.Select(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if actualValue, _ := selectedList.Get(0); actualValue != "a" {
@@ -312,13 +312,13 @@ func TestListSelect(t *testing.T) {
 func TestListAny(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	any := list.Any(func(index int, value interface{}) bool {
+	any := list.Any(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = list.Any(func(index int, value interface{}) bool {
+	any = list.Any(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if any != false {
@@ -328,13 +328,13 @@ func TestListAny(t *testing.T) {
 func TestListAll(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	all := list.All(func(index int, value interface{}) bool {
+	all := list.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = list.All(func(index int, value interface{}) bool {
+	all = list.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if all != false {
@@ -344,13 +344,13 @@ func TestListAll(t *testing.T) {
 func TestListFind(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	foundIndex, foundValue := list.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue := list.Find(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if foundValue != "c" || foundIndex != 2 {
 		t.Errorf("Got %v at %v expected %v at %v", foundValue, foundIndex, "c", 2)
 	}
-	foundIndex, foundValue = list.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue = list.Find(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if foundValue != nil || foundIndex != -1 {
@@ -360,9 +360,9 @@ func TestListFind(t *testing.T) {
 func TestListChaining(t *testing.T) {
 	list := New()
 	list.Add("a", "b", "c")
-	chainedList := list.Select(func(index int, value interface{}) bool {
+	chainedList := list.Select(func(index int, value any) bool {
 		return value.(string) > "a"
-	}).Map(func(index int, value interface{}) interface{} {
+	}).Map(func(index int, value any) any {
 		return value.(string) + value.(string)
 	})
 	if chainedList.Size() != 2 {
@@ -446,7 +446,7 @@ func TestListIteratorFirst(t *testing.T) {
 
 func TestListIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -518,7 +518,7 @@ func TestListSerialization(t *testing.T) {
 	err = list.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", list})
+	bytes, err = json.Marshal([]any{"a", "b", "c", list})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/maps/hashbidimap/hashbidimap.go
+++ b/maps/hashbidimap/hashbidimap.go
@@ -36,7 +36,7 @@ func New() *Map {
 }
 
 // Put inserts element into the map.
-func (m *Map) Put(key interface{}, value interface{}) {
+func (m *Map) Put(key any, value any) {
 	if valueByKey, ok := m.forwardMap.Get(key); ok {
 		m.inverseMap.Remove(valueByKey)
 	}
@@ -49,18 +49,18 @@ func (m *Map) Put(key interface{}, value interface{}) {
 
 // Get searches the element in the map by key and returns its value or nil if key is not found in map.
 // Second return parameter is true if key was found, otherwise false.
-func (m *Map) Get(key interface{}) (value interface{}, found bool) {
+func (m *Map) Get(key any) (value any, found bool) {
 	return m.forwardMap.Get(key)
 }
 
 // GetKey searches the element in the map by value and returns its key or nil if value is not found in map.
 // Second return parameter is true if value was found, otherwise false.
-func (m *Map) GetKey(value interface{}) (key interface{}, found bool) {
+func (m *Map) GetKey(value any) (key any, found bool) {
 	return m.inverseMap.Get(value)
 }
 
 // Remove removes the element from the map by key.
-func (m *Map) Remove(key interface{}) {
+func (m *Map) Remove(key any) {
 	if value, found := m.forwardMap.Get(key); found {
 		m.forwardMap.Remove(key)
 		m.inverseMap.Remove(value)
@@ -78,12 +78,12 @@ func (m *Map) Size() int {
 }
 
 // Keys returns all keys (random order).
-func (m *Map) Keys() []interface{} {
+func (m *Map) Keys() []any {
 	return m.forwardMap.Keys()
 }
 
 // Values returns all values (random order).
-func (m *Map) Values() []interface{} {
+func (m *Map) Values() []any {
 	return m.inverseMap.Keys()
 }
 

--- a/maps/hashbidimap/hashbidimap_test.go
+++ b/maps/hashbidimap/hashbidimap_test.go
@@ -25,15 +25,15 @@ func TestMapPut(t *testing.T) {
 	if actualValue := m.Size(); actualValue != 7 {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -70,18 +70,18 @@ func TestMapRemove(t *testing.T) {
 	m.Remove(8)
 	m.Remove(5)
 
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue := m.Size(); actualValue != 4 {
 		t.Errorf("Got %v expected %v", actualValue, 4)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -132,7 +132,7 @@ func TestMapGetKey(t *testing.T) {
 	m.Put(1, "a") //overwrite
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -160,10 +160,10 @@ func TestMapSerialization(t *testing.T) {
 
 	var err error
 	assert := func() {
-		if actualValue, expectedValue := m.Keys(), []interface{}{"a", "b", "c"}; !sameElements(actualValue, expectedValue) {
+		if actualValue, expectedValue := m.Keys(), []any{"a", "b", "c"}; !sameElements(actualValue, expectedValue) {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
-		if actualValue, expectedValue := m.Values(), []interface{}{1.0, 2.0, 3.0}; !sameElements(actualValue, expectedValue) {
+		if actualValue, expectedValue := m.Values(), []any{1.0, 2.0, 3.0}; !sameElements(actualValue, expectedValue) {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
 		if actualValue, expectedValue := m.Size(), 3; actualValue != expectedValue {
@@ -182,7 +182,7 @@ func TestMapSerialization(t *testing.T) {
 	err = m.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", m})
+	bytes, err = json.Marshal([]any{"a", "b", "c", m})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}
@@ -201,7 +201,7 @@ func TestMapString(t *testing.T) {
 	}
 }
 
-func sameElements(a []interface{}, b []interface{}) bool {
+func sameElements(a []any, b []any) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/maps/hashbidimap/serialization.go
+++ b/maps/hashbidimap/serialization.go
@@ -20,7 +20,7 @@ func (m *Map) ToJSON() ([]byte, error) {
 
 // FromJSON populates the map from the input JSON representation.
 func (m *Map) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		m.Clear()

--- a/maps/hashmap/hashmap.go
+++ b/maps/hashmap/hashmap.go
@@ -21,28 +21,28 @@ var _ maps.Map = (*Map)(nil)
 
 // Map holds the elements in go's native map
 type Map struct {
-	m map[interface{}]interface{}
+	m map[any]any
 }
 
 // New instantiates a hash map.
 func New() *Map {
-	return &Map{m: make(map[interface{}]interface{})}
+	return &Map{m: make(map[any]any)}
 }
 
 // Put inserts element into the map.
-func (m *Map) Put(key interface{}, value interface{}) {
+func (m *Map) Put(key any, value any) {
 	m.m[key] = value
 }
 
 // Get searches the element in the map by key and returns its value or nil if key is not found in map.
 // Second return parameter is true if key was found, otherwise false.
-func (m *Map) Get(key interface{}) (value interface{}, found bool) {
+func (m *Map) Get(key any) (value any, found bool) {
 	value, found = m.m[key]
 	return
 }
 
 // Remove removes the element from the map by key.
-func (m *Map) Remove(key interface{}) {
+func (m *Map) Remove(key any) {
 	delete(m.m, key)
 }
 
@@ -57,8 +57,8 @@ func (m *Map) Size() int {
 }
 
 // Keys returns all keys (random order).
-func (m *Map) Keys() []interface{} {
-	keys := make([]interface{}, m.Size())
+func (m *Map) Keys() []any {
+	keys := make([]any, m.Size())
 	count := 0
 	for key := range m.m {
 		keys[count] = key
@@ -68,8 +68,8 @@ func (m *Map) Keys() []interface{} {
 }
 
 // Values returns all values (random order).
-func (m *Map) Values() []interface{} {
-	values := make([]interface{}, m.Size())
+func (m *Map) Values() []any {
+	values := make([]any, m.Size())
 	count := 0
 	for _, value := range m.m {
 		values[count] = value
@@ -80,7 +80,7 @@ func (m *Map) Values() []interface{} {
 
 // Clear removes all elements from the map.
 func (m *Map) Clear() {
-	m.m = make(map[interface{}]interface{})
+	m.m = make(map[any]any)
 }
 
 // String returns a string representation of container

--- a/maps/hashmap/hashmap_test.go
+++ b/maps/hashmap/hashmap_test.go
@@ -25,15 +25,15 @@ func TestMapPut(t *testing.T) {
 	if actualValue := m.Size(); actualValue != 7 {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -70,18 +70,18 @@ func TestMapRemove(t *testing.T) {
 	m.Remove(8)
 	m.Remove(5)
 
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue := m.Size(); actualValue != 4 {
 		t.Errorf("Got %v expected %v", actualValue, 4)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -128,10 +128,10 @@ func TestMapSerialization(t *testing.T) {
 
 	var err error
 	assert := func() {
-		if actualValue, expectedValue := m.Keys(), []interface{}{"a", "b", "c"}; !sameElements(actualValue, expectedValue) {
+		if actualValue, expectedValue := m.Keys(), []any{"a", "b", "c"}; !sameElements(actualValue, expectedValue) {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
-		if actualValue, expectedValue := m.Values(), []interface{}{1.0, 2.0, 3.0}; !sameElements(actualValue, expectedValue) {
+		if actualValue, expectedValue := m.Values(), []any{1.0, 2.0, 3.0}; !sameElements(actualValue, expectedValue) {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
 		if actualValue, expectedValue := m.Size(), 3; actualValue != expectedValue {
@@ -150,7 +150,7 @@ func TestMapSerialization(t *testing.T) {
 	err = m.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", m})
+	bytes, err = json.Marshal([]any{"a", "b", "c", m})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}
@@ -169,7 +169,7 @@ func TestMapString(t *testing.T) {
 	}
 }
 
-func sameElements(a []interface{}, b []interface{}) bool {
+func sameElements(a []any, b []any) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/maps/hashmap/serialization.go
+++ b/maps/hashmap/serialization.go
@@ -16,7 +16,7 @@ var _ containers.JSONDeserializer = (*Map)(nil)
 
 // ToJSON outputs the JSON representation of the map.
 func (m *Map) ToJSON() ([]byte, error) {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	for key, value := range m.m {
 		elements[utils.ToString(key)] = value
 	}
@@ -25,7 +25,7 @@ func (m *Map) ToJSON() ([]byte, error) {
 
 // FromJSON populates the map from the input JSON representation.
 func (m *Map) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		m.Clear()

--- a/maps/linkedhashmap/enumerable.go
+++ b/maps/linkedhashmap/enumerable.go
@@ -10,7 +10,7 @@ import "github.com/emirpasic/gods/containers"
 var _ containers.EnumerableWithKey = (*Map)(nil)
 
 // Each calls the given function once for each element, passing that element's key and value.
-func (m *Map) Each(f func(key interface{}, value interface{})) {
+func (m *Map) Each(f func(key any, value any)) {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		f(iterator.Key(), iterator.Value())
@@ -19,7 +19,7 @@ func (m *Map) Each(f func(key interface{}, value interface{})) {
 
 // Map invokes the given function once for each element and returns a container
 // containing the values returned by the given function as key/value pairs.
-func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, interface{})) *Map {
+func (m *Map) Map(f func(key1 any, value1 any) (any, any)) *Map {
 	newMap := New()
 	iterator := m.Iterator()
 	for iterator.Next() {
@@ -30,7 +30,7 @@ func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, int
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
+func (m *Map) Select(f func(key any, value any) bool) *Map {
 	newMap := New()
 	iterator := m.Iterator()
 	for iterator.Next() {
@@ -43,7 +43,7 @@ func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
+func (m *Map) Any(f func(key any, value any) bool) bool {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {
@@ -55,7 +55,7 @@ func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
+func (m *Map) All(f func(key any, value any) bool) bool {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Key(), iterator.Value()) {
@@ -68,7 +68,7 @@ func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (key,value) for which the function is true or nil,nil otherwise if no element
 // matches the criteria.
-func (m *Map) Find(f func(key interface{}, value interface{}) bool) (interface{}, interface{}) {
+func (m *Map) Find(f func(key any, value any) bool) (any, any) {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {

--- a/maps/linkedhashmap/iterator.go
+++ b/maps/linkedhashmap/iterator.go
@@ -15,7 +15,7 @@ var _ containers.ReverseIteratorWithKey = (*Iterator)(nil)
 // Iterator holding the iterator's state
 type Iterator struct {
 	iterator doublylinkedlist.Iterator
-	table    map[interface{}]interface{}
+	table    map[any]any
 }
 
 // Iterator returns a stateful iterator whose elements are key/value pairs.
@@ -42,14 +42,14 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	key := iterator.iterator.Value()
 	return iterator.table[key]
 }
 
 // Key returns the current element's key.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Key() interface{} {
+func (iterator *Iterator) Key() any {
 	return iterator.iterator.Value()
 }
 
@@ -83,7 +83,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(key any, value any) bool) bool {
 	for iterator.Next() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {
@@ -97,7 +97,7 @@ func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(key any, value any) bool) bool {
 	for iterator.Prev() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {

--- a/maps/linkedhashmap/linkedhashmap.go
+++ b/maps/linkedhashmap/linkedhashmap.go
@@ -23,21 +23,21 @@ var _ maps.Map = (*Map)(nil)
 
 // Map holds the elements in a regular hash table, and uses doubly-linked list to store key ordering.
 type Map struct {
-	table    map[interface{}]interface{}
+	table    map[any]any
 	ordering *doublylinkedlist.List
 }
 
 // New instantiates a linked-hash-map.
 func New() *Map {
 	return &Map{
-		table:    make(map[interface{}]interface{}),
+		table:    make(map[any]any),
 		ordering: doublylinkedlist.New(),
 	}
 }
 
 // Put inserts key-value pair into the map.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Put(key interface{}, value interface{}) {
+func (m *Map) Put(key any, value any) {
 	if _, contains := m.table[key]; !contains {
 		m.ordering.Append(key)
 	}
@@ -47,7 +47,7 @@ func (m *Map) Put(key interface{}, value interface{}) {
 // Get searches the element in the map by key and returns its value or nil if key is not found in tree.
 // Second return parameter is true if key was found, otherwise false.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Get(key interface{}) (value interface{}, found bool) {
+func (m *Map) Get(key any) (value any, found bool) {
 	value = m.table[key]
 	found = value != nil
 	return
@@ -55,7 +55,7 @@ func (m *Map) Get(key interface{}) (value interface{}, found bool) {
 
 // Remove removes the element from the map by key.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Remove(key interface{}) {
+func (m *Map) Remove(key any) {
 	if _, contains := m.table[key]; contains {
 		delete(m.table, key)
 		index := m.ordering.IndexOf(key)
@@ -74,13 +74,13 @@ func (m *Map) Size() int {
 }
 
 // Keys returns all keys in-order
-func (m *Map) Keys() []interface{} {
+func (m *Map) Keys() []any {
 	return m.ordering.Values()
 }
 
 // Values returns all values in-order based on the key.
-func (m *Map) Values() []interface{} {
-	values := make([]interface{}, m.Size())
+func (m *Map) Values() []any {
+	values := make([]any, m.Size())
 	count := 0
 	it := m.Iterator()
 	for it.Next() {
@@ -92,7 +92,7 @@ func (m *Map) Values() []interface{} {
 
 // Clear removes all elements from the map.
 func (m *Map) Clear() {
-	m.table = make(map[interface{}]interface{})
+	m.table = make(map[any]any)
 	m.ordering.Clear()
 }
 

--- a/maps/linkedhashmap/linkedhashmap_test.go
+++ b/maps/linkedhashmap/linkedhashmap_test.go
@@ -25,15 +25,15 @@ func TestMapPut(t *testing.T) {
 	if actualValue := m.Size(); actualValue != 7 {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
-	if actualValue, expectedValue := m.Keys(), []interface{}{5, 6, 7, 3, 4, 1, 2}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{5, 6, 7, 3, 4, 1, 2}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
-	if actualValue, expectedValue := m.Values(), []interface{}{"e", "f", "g", "c", "d", "a", "b"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"e", "f", "g", "c", "d", "a", "b"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -70,18 +70,18 @@ func TestMapRemove(t *testing.T) {
 	m.Remove(8)
 	m.Remove(5)
 
-	if actualValue, expectedValue := m.Keys(), []interface{}{3, 4, 1, 2}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{3, 4, 1, 2}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := m.Values(), []interface{}{"c", "d", "a", "b"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"c", "d", "a", "b"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue := m.Size(); actualValue != 4 {
 		t.Errorf("Got %v expected %v", actualValue, 4)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -120,7 +120,7 @@ func TestMapRemove(t *testing.T) {
 	}
 }
 
-func sameElements(a []interface{}, b []interface{}) bool {
+func sameElements(a []any, b []any) bool {
 	// If one is nil, the other must also be nil.
 	if (a == nil) != (b == nil) {
 		return false
@@ -145,7 +145,7 @@ func TestMapEach(t *testing.T) {
 	m.Put("a", 2)
 	m.Put("b", 3)
 	count := 0
-	m.Each(func(key interface{}, value interface{}) {
+	m.Each(func(key any, value any) {
 		count++
 		if actualValue, expectedValue := count, value; actualValue != expectedValue {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -174,7 +174,7 @@ func TestMapMap(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	mappedMap := m.Map(func(key1 interface{}, value1 interface{}) (key2 interface{}, value2 interface{}) {
+	mappedMap := m.Map(func(key1 any, value1 any) (key2 any, value2 any) {
 		return key1, value1.(int) * value1.(int)
 	})
 	if actualValue, _ := mappedMap.Get("c"); actualValue != 9 {
@@ -196,7 +196,7 @@ func TestMapSelect(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("b", 1)
 	m.Put("a", 2)
-	selectedMap := m.Select(func(key interface{}, value interface{}) bool {
+	selectedMap := m.Select(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "b"
 	})
 	if actualValue, _ := selectedMap.Get("b"); actualValue != 1 {
@@ -215,13 +215,13 @@ func TestMapAny(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	any := m.Any(func(key interface{}, value interface{}) bool {
+	any := m.Any(func(key any, value any) bool {
 		return value.(int) == 3
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = m.Any(func(key interface{}, value interface{}) bool {
+	any = m.Any(func(key any, value any) bool {
 		return value.(int) == 4
 	})
 	if any != false {
@@ -234,13 +234,13 @@ func TestMapAll(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	all := m.All(func(key interface{}, value interface{}) bool {
+	all := m.All(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = m.All(func(key interface{}, value interface{}) bool {
+	all = m.All(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "b"
 	})
 	if all != false {
@@ -253,13 +253,13 @@ func TestMapFind(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	foundKey, foundValue := m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue := m.Find(func(key any, value any) bool {
 		return key.(string) == "c"
 	})
 	if foundKey != "c" || foundValue != 3 {
 		t.Errorf("Got %v -> %v expected %v -> %v", foundKey, foundValue, "c", 3)
 	}
-	foundKey, foundValue = m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue = m.Find(func(key any, value any) bool {
 		return key.(string) == "x"
 	})
 	if foundKey != nil || foundValue != nil {
@@ -272,9 +272,9 @@ func TestMapChaining(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	chainedMap := m.Select(func(key interface{}, value interface{}) bool {
+	chainedMap := m.Select(func(key any, value any) bool {
 		return value.(int) > 1
-	}).Map(func(key interface{}, value interface{}) (interface{}, interface{}) {
+	}).Map(func(key any, value any) (any, any) {
 		return key.(string) + key.(string), value.(int) * value.(int)
 	})
 	if actualValue := chainedMap.Size(); actualValue != 2 {
@@ -444,7 +444,7 @@ func TestMapIteratorLast(t *testing.T) {
 
 func TestMapIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -496,7 +496,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 func TestMapIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -578,7 +578,7 @@ func TestMapSerialization(t *testing.T) {
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
 
-	_, err := json.Marshal([]interface{}{"a", "b", "c", m})
+	_, err := json.Marshal([]any{"a", "b", "c", m})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}
@@ -597,7 +597,7 @@ func TestMapString(t *testing.T) {
 	}
 }
 
-//noinspection GoBoolExpressions
+// noinspection GoBoolExpressions
 func assertSerialization(m *Map, txt string, t *testing.T) {
 	if actualValue := m.Keys(); false ||
 		actualValue[0].(string) != "d" ||

--- a/maps/linkedhashmap/serialization.go
+++ b/maps/linkedhashmap/serialization.go
@@ -68,21 +68,21 @@ func (m *Map) ToJSON() ([]byte, error) {
 
 // FromJSON populates map from the input JSON representation.
 func (m *Map) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err != nil {
 		return err
 	}
 
 	index := make(map[string]int)
-	var keys []interface{}
+	var keys []any
 	for key := range elements {
 		keys = append(keys, key)
 		esc, _ := json.Marshal(key)
 		index[key] = bytes.Index(data, esc)
 	}
 
-	byIndex := func(a, b interface{}) int {
+	byIndex := func(a, b any) int {
 		key1 := a.(string)
 		key2 := b.(string)
 		index1 := index[key1]

--- a/maps/maps.go
+++ b/maps/maps.go
@@ -19,10 +19,10 @@ import "github.com/emirpasic/gods/containers"
 
 // Map interface that all maps implement
 type Map interface {
-	Put(key interface{}, value interface{})
-	Get(key interface{}) (value interface{}, found bool)
-	Remove(key interface{})
-	Keys() []interface{}
+	Put(key any, value any)
+	Get(key any) (value any, found bool)
+	Remove(key any)
+	Keys() []any
 
 	containers.Container
 	// Empty() bool
@@ -34,7 +34,7 @@ type Map interface {
 
 // BidiMap interface that all bidirectional maps implement (extends the Map interface)
 type BidiMap interface {
-	GetKey(value interface{}) (key interface{}, found bool)
+	GetKey(value any) (key any, found bool)
 
 	Map
 }

--- a/maps/treebidimap/enumerable.go
+++ b/maps/treebidimap/enumerable.go
@@ -10,7 +10,7 @@ import "github.com/emirpasic/gods/containers"
 var _ containers.EnumerableWithKey = (*Map)(nil)
 
 // Each calls the given function once for each element, passing that element's key and value.
-func (m *Map) Each(f func(key interface{}, value interface{})) {
+func (m *Map) Each(f func(key any, value any)) {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		f(iterator.Key(), iterator.Value())
@@ -19,7 +19,7 @@ func (m *Map) Each(f func(key interface{}, value interface{})) {
 
 // Map invokes the given function once for each element and returns a container
 // containing the values returned by the given function as key/value pairs.
-func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, interface{})) *Map {
+func (m *Map) Map(f func(key1 any, value1 any) (any, any)) *Map {
 	newMap := NewWith(m.keyComparator, m.valueComparator)
 	iterator := m.Iterator()
 	for iterator.Next() {
@@ -30,7 +30,7 @@ func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, int
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
+func (m *Map) Select(f func(key any, value any) bool) *Map {
 	newMap := NewWith(m.keyComparator, m.valueComparator)
 	iterator := m.Iterator()
 	for iterator.Next() {
@@ -43,7 +43,7 @@ func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
+func (m *Map) Any(f func(key any, value any) bool) bool {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {
@@ -55,7 +55,7 @@ func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
+func (m *Map) All(f func(key any, value any) bool) bool {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Key(), iterator.Value()) {
@@ -68,7 +68,7 @@ func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (key,value) for which the function is true or nil,nil otherwise if no element
 // matches the criteria.
-func (m *Map) Find(f func(key interface{}, value interface{}) bool) (interface{}, interface{}) {
+func (m *Map) Find(f func(key any, value any) bool) (any, any) {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {

--- a/maps/treebidimap/iterator.go
+++ b/maps/treebidimap/iterator.go
@@ -39,13 +39,13 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.iterator.Value().(*data).value
 }
 
 // Key returns the current element's key.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Key() interface{} {
+func (iterator *Iterator) Key() any {
 	return iterator.iterator.Key()
 }
 
@@ -79,7 +79,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(key any, value any) bool) bool {
 	for iterator.Next() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {
@@ -93,7 +93,7 @@ func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(key any, value any) bool) bool {
 	for iterator.Prev() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {

--- a/maps/treebidimap/serialization.go
+++ b/maps/treebidimap/serialization.go
@@ -16,7 +16,7 @@ var _ containers.JSONDeserializer = (*Map)(nil)
 
 // ToJSON outputs the JSON representation of the map.
 func (m *Map) ToJSON() ([]byte, error) {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	it := m.Iterator()
 	for it.Next() {
 		elements[utils.ToString(it.Key())] = it.Value()
@@ -26,7 +26,7 @@ func (m *Map) ToJSON() ([]byte, error) {
 
 // FromJSON populates the map from the input JSON representation.
 func (m *Map) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		m.Clear()

--- a/maps/treebidimap/treebidimap.go
+++ b/maps/treebidimap/treebidimap.go
@@ -37,8 +37,8 @@ type Map struct {
 }
 
 type data struct {
-	key   interface{}
-	value interface{}
+	key   any
+	value any
 }
 
 // NewWith instantiates a bidirectional map.
@@ -62,7 +62,7 @@ func NewWithStringComparators() *Map {
 }
 
 // Put inserts element into the map.
-func (m *Map) Put(key interface{}, value interface{}) {
+func (m *Map) Put(key any, value any) {
 	if d, ok := m.forwardMap.Get(key); ok {
 		m.inverseMap.Remove(d.(*data).value)
 	}
@@ -76,7 +76,7 @@ func (m *Map) Put(key interface{}, value interface{}) {
 
 // Get searches the element in the map by key and returns its value or nil if key is not found in map.
 // Second return parameter is true if key was found, otherwise false.
-func (m *Map) Get(key interface{}) (value interface{}, found bool) {
+func (m *Map) Get(key any) (value any, found bool) {
 	if d, ok := m.forwardMap.Get(key); ok {
 		return d.(*data).value, true
 	}
@@ -85,7 +85,7 @@ func (m *Map) Get(key interface{}) (value interface{}, found bool) {
 
 // GetKey searches the element in the map by value and returns its key or nil if value is not found in map.
 // Second return parameter is true if value was found, otherwise false.
-func (m *Map) GetKey(value interface{}) (key interface{}, found bool) {
+func (m *Map) GetKey(value any) (key any, found bool) {
 	if d, ok := m.inverseMap.Get(value); ok {
 		return d.(*data).key, true
 	}
@@ -93,7 +93,7 @@ func (m *Map) GetKey(value interface{}) (key interface{}, found bool) {
 }
 
 // Remove removes the element from the map by key.
-func (m *Map) Remove(key interface{}) {
+func (m *Map) Remove(key any) {
 	if d, found := m.forwardMap.Get(key); found {
 		m.forwardMap.Remove(key)
 		m.inverseMap.Remove(d.(*data).value)
@@ -111,12 +111,12 @@ func (m *Map) Size() int {
 }
 
 // Keys returns all keys (ordered).
-func (m *Map) Keys() []interface{} {
+func (m *Map) Keys() []any {
 	return m.forwardMap.Keys()
 }
 
 // Values returns all values (ordered).
-func (m *Map) Values() []interface{} {
+func (m *Map) Values() []any {
 	return m.inverseMap.Keys()
 }
 

--- a/maps/treebidimap/treebidimap_test.go
+++ b/maps/treebidimap/treebidimap_test.go
@@ -26,15 +26,15 @@ func TestMapPut(t *testing.T) {
 	if actualValue := m.Size(); actualValue != 7 {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -71,18 +71,18 @@ func TestMapRemove(t *testing.T) {
 	m.Remove(8)
 	m.Remove(5)
 
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue := m.Size(); actualValue != 4 {
 		t.Errorf("Got %v expected %v", actualValue, 4)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -133,7 +133,7 @@ func TestMapGetKey(t *testing.T) {
 	m.Put(1, "a") //overwrite
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -153,7 +153,7 @@ func TestMapGetKey(t *testing.T) {
 	}
 }
 
-func sameElements(a []interface{}, b []interface{}) bool {
+func sameElements(a []any, b []any) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -178,7 +178,7 @@ func TestMapEach(t *testing.T) {
 	m.Put("a", 1)
 	m.Put("b", 2)
 	count := 0
-	m.Each(func(key interface{}, value interface{}) {
+	m.Each(func(key any, value any) {
 		count++
 		if actualValue, expectedValue := count, value; actualValue != expectedValue {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -207,7 +207,7 @@ func TestMapMap(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	mappedMap := m.Map(func(key1 interface{}, value1 interface{}) (key2 interface{}, value2 interface{}) {
+	mappedMap := m.Map(func(key1 any, value1 any) (key2 any, value2 any) {
 		return key1, value1.(int) * value1.(int)
 	})
 	if actualValue, _ := mappedMap.Get("a"); actualValue != 1 {
@@ -229,7 +229,7 @@ func TestMapSelect(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	selectedMap := m.Select(func(key interface{}, value interface{}) bool {
+	selectedMap := m.Select(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "b"
 	})
 	if actualValue, _ := selectedMap.Get("a"); actualValue != 1 {
@@ -248,13 +248,13 @@ func TestMapAny(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	any := m.Any(func(key interface{}, value interface{}) bool {
+	any := m.Any(func(key any, value any) bool {
 		return value.(int) == 3
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = m.Any(func(key interface{}, value interface{}) bool {
+	any = m.Any(func(key any, value any) bool {
 		return value.(int) == 4
 	})
 	if any != false {
@@ -267,13 +267,13 @@ func TestMapAll(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	all := m.All(func(key interface{}, value interface{}) bool {
+	all := m.All(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = m.All(func(key interface{}, value interface{}) bool {
+	all = m.All(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "b"
 	})
 	if all != false {
@@ -286,13 +286,13 @@ func TestMapFind(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	foundKey, foundValue := m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue := m.Find(func(key any, value any) bool {
 		return key.(string) == "c"
 	})
 	if foundKey != "c" || foundValue != 3 {
 		t.Errorf("Got %v -> %v expected %v -> %v", foundKey, foundValue, "c", 3)
 	}
-	foundKey, foundValue = m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue = m.Find(func(key any, value any) bool {
 		return key.(string) == "x"
 	})
 	if foundKey != nil || foundValue != nil {
@@ -305,9 +305,9 @@ func TestMapChaining(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	chainedMap := m.Select(func(key interface{}, value interface{}) bool {
+	chainedMap := m.Select(func(key any, value any) bool {
 		return value.(int) > 1
-	}).Map(func(key interface{}, value interface{}) (interface{}, interface{}) {
+	}).Map(func(key any, value any) (any, any) {
 		return key.(string) + key.(string), value.(int) * value.(int)
 	})
 	if actualValue := chainedMap.Size(); actualValue != 2 {
@@ -477,7 +477,7 @@ func TestMapIteratorLast(t *testing.T) {
 
 func TestMapIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -529,7 +529,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 func TestMapIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -611,7 +611,7 @@ func TestMapSerialization(t *testing.T) {
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
 
-	_, err := json.Marshal([]interface{}{"a", "b", "c", m})
+	_, err := json.Marshal([]any{"a", "b", "c", m})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}
@@ -630,7 +630,7 @@ func TestMapString(t *testing.T) {
 	}
 }
 
-//noinspection GoBoolExpressions
+// noinspection GoBoolExpressions
 func assertSerialization(m *Map, txt string, t *testing.T) {
 	if actualValue := m.Keys(); false ||
 		actualValue[0].(string) != "a" ||

--- a/maps/treemap/enumerable.go
+++ b/maps/treemap/enumerable.go
@@ -13,7 +13,7 @@ import (
 var _ containers.EnumerableWithKey = (*Map)(nil)
 
 // Each calls the given function once for each element, passing that element's key and value.
-func (m *Map) Each(f func(key interface{}, value interface{})) {
+func (m *Map) Each(f func(key any, value any)) {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		f(iterator.Key(), iterator.Value())
@@ -22,7 +22,7 @@ func (m *Map) Each(f func(key interface{}, value interface{})) {
 
 // Map invokes the given function once for each element and returns a container
 // containing the values returned by the given function as key/value pairs.
-func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, interface{})) *Map {
+func (m *Map) Map(f func(key1 any, value1 any) (any, any)) *Map {
 	newMap := &Map{tree: rbt.NewWith(m.tree.Comparator)}
 	iterator := m.Iterator()
 	for iterator.Next() {
@@ -33,7 +33,7 @@ func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, int
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
+func (m *Map) Select(f func(key any, value any) bool) *Map {
 	newMap := &Map{tree: rbt.NewWith(m.tree.Comparator)}
 	iterator := m.Iterator()
 	for iterator.Next() {
@@ -46,7 +46,7 @@ func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
+func (m *Map) Any(f func(key any, value any) bool) bool {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {
@@ -58,7 +58,7 @@ func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
+func (m *Map) All(f func(key any, value any) bool) bool {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Key(), iterator.Value()) {
@@ -71,7 +71,7 @@ func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (key,value) for which the function is true or nil,nil otherwise if no element
 // matches the criteria.
-func (m *Map) Find(f func(key interface{}, value interface{}) bool) (interface{}, interface{}) {
+func (m *Map) Find(f func(key any, value any) bool) (any, any) {
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {

--- a/maps/treemap/iterator.go
+++ b/maps/treemap/iterator.go
@@ -39,13 +39,13 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.iterator.Value()
 }
 
 // Key returns the current element's key.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Key() interface{} {
+func (iterator *Iterator) Key() any {
 	return iterator.iterator.Key()
 }
 
@@ -79,7 +79,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(key any, value any) bool) bool {
 	for iterator.Next() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {
@@ -93,7 +93,7 @@ func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(key any, value any) bool) bool {
 	for iterator.Prev() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {

--- a/maps/treemap/treemap.go
+++ b/maps/treemap/treemap.go
@@ -44,20 +44,20 @@ func NewWithStringComparator() *Map {
 
 // Put inserts key-value pair into the map.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Put(key interface{}, value interface{}) {
+func (m *Map) Put(key any, value any) {
 	m.tree.Put(key, value)
 }
 
 // Get searches the element in the map by key and returns its value or nil if key is not found in tree.
 // Second return parameter is true if key was found, otherwise false.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Get(key interface{}) (value interface{}, found bool) {
+func (m *Map) Get(key any) (value any, found bool) {
 	return m.tree.Get(key)
 }
 
 // Remove removes the element from the map by key.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Remove(key interface{}) {
+func (m *Map) Remove(key any) {
 	m.tree.Remove(key)
 }
 
@@ -72,12 +72,12 @@ func (m *Map) Size() int {
 }
 
 // Keys returns all keys in-order
-func (m *Map) Keys() []interface{} {
+func (m *Map) Keys() []any {
 	return m.tree.Keys()
 }
 
 // Values returns all values in-order based on the key.
-func (m *Map) Values() []interface{} {
+func (m *Map) Values() []any {
 	return m.tree.Values()
 }
 
@@ -88,7 +88,7 @@ func (m *Map) Clear() {
 
 // Min returns the minimum key and its value from the tree map.
 // Returns nil, nil if map is empty.
-func (m *Map) Min() (key interface{}, value interface{}) {
+func (m *Map) Min() (key any, value any) {
 	if node := m.tree.Left(); node != nil {
 		return node.Key, node.Value
 	}
@@ -97,7 +97,7 @@ func (m *Map) Min() (key interface{}, value interface{}) {
 
 // Max returns the maximum key and its value from the tree map.
 // Returns nil, nil if map is empty.
-func (m *Map) Max() (key interface{}, value interface{}) {
+func (m *Map) Max() (key any, value any) {
 	if node := m.tree.Right(); node != nil {
 		return node.Key, node.Value
 	}
@@ -113,7 +113,7 @@ func (m *Map) Max() (key interface{}, value interface{}) {
 // all keys in the map are larger than the given key.
 //
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Floor(key interface{}) (foundKey interface{}, foundValue interface{}) {
+func (m *Map) Floor(key any) (foundKey any, foundValue any) {
 	node, found := m.tree.Floor(key)
 	if found {
 		return node.Key, node.Value
@@ -130,7 +130,7 @@ func (m *Map) Floor(key interface{}) (foundKey interface{}, foundValue interface
 // all keys in the map are smaller than the given key.
 //
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (m *Map) Ceiling(key interface{}) (foundKey interface{}, foundValue interface{}) {
+func (m *Map) Ceiling(key any) (foundKey any, foundValue any) {
 	node, found := m.tree.Ceiling(key)
 	if found {
 		return node.Key, node.Value

--- a/maps/treemap/treemap_test.go
+++ b/maps/treemap/treemap_test.go
@@ -26,15 +26,15 @@ func TestMapPut(t *testing.T) {
 	if actualValue := m.Size(); actualValue != 7 {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4, 5, 6, 7}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d", "e", "f", "g"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
 	// key,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -138,18 +138,18 @@ func TestMapRemove(t *testing.T) {
 	m.Remove(8)
 	m.Remove(5)
 
-	if actualValue, expectedValue := m.Keys(), []interface{}{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Keys(), []any{1, 2, 3, 4}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := m.Values(), []interface{}{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
+	if actualValue, expectedValue := m.Values(), []any{"a", "b", "c", "d"}; !sameElements(actualValue, expectedValue) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue := m.Size(); actualValue != 4 {
 		t.Errorf("Got %v expected %v", actualValue, 4)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -195,7 +195,7 @@ func TestMapFloor(t *testing.T) {
 	m.Put(1, "a")
 
 	// key,expectedKey,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{-1, nil, nil, false},
 		{0, nil, nil, false},
 		{1, 1, "a", true},
@@ -223,7 +223,7 @@ func TestMapCeiling(t *testing.T) {
 	m.Put(1, "a")
 
 	// key,expectedKey,expectedValue,expectedFound
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{-1, 1, "a", true},
 		{0, 1, "a", true},
 		{1, 1, "a", true},
@@ -244,7 +244,7 @@ func TestMapCeiling(t *testing.T) {
 	}
 }
 
-func sameElements(a []interface{}, b []interface{}) bool {
+func sameElements(a []any, b []any) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -269,7 +269,7 @@ func TestMapEach(t *testing.T) {
 	m.Put("a", 1)
 	m.Put("b", 2)
 	count := 0
-	m.Each(func(key interface{}, value interface{}) {
+	m.Each(func(key any, value any) {
 		count++
 		if actualValue, expectedValue := count, value; actualValue != expectedValue {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -298,7 +298,7 @@ func TestMapMap(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	mappedMap := m.Map(func(key1 interface{}, value1 interface{}) (key2 interface{}, value2 interface{}) {
+	mappedMap := m.Map(func(key1 any, value1 any) (key2 any, value2 any) {
 		return key1, value1.(int) * value1.(int)
 	})
 	if actualValue, _ := mappedMap.Get("a"); actualValue != 1 {
@@ -320,7 +320,7 @@ func TestMapSelect(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	selectedMap := m.Select(func(key interface{}, value interface{}) bool {
+	selectedMap := m.Select(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "b"
 	})
 	if actualValue, _ := selectedMap.Get("a"); actualValue != 1 {
@@ -339,13 +339,13 @@ func TestMapAny(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	any := m.Any(func(key interface{}, value interface{}) bool {
+	any := m.Any(func(key any, value any) bool {
 		return value.(int) == 3
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = m.Any(func(key interface{}, value interface{}) bool {
+	any = m.Any(func(key any, value any) bool {
 		return value.(int) == 4
 	})
 	if any != false {
@@ -358,13 +358,13 @@ func TestMapAll(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	all := m.All(func(key interface{}, value interface{}) bool {
+	all := m.All(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = m.All(func(key interface{}, value interface{}) bool {
+	all = m.All(func(key any, value any) bool {
 		return key.(string) >= "a" && key.(string) <= "b"
 	})
 	if all != false {
@@ -377,13 +377,13 @@ func TestMapFind(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	foundKey, foundValue := m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue := m.Find(func(key any, value any) bool {
 		return key.(string) == "c"
 	})
 	if foundKey != "c" || foundValue != 3 {
 		t.Errorf("Got %v -> %v expected %v -> %v", foundKey, foundValue, "c", 3)
 	}
-	foundKey, foundValue = m.Find(func(key interface{}, value interface{}) bool {
+	foundKey, foundValue = m.Find(func(key any, value any) bool {
 		return key.(string) == "x"
 	})
 	if foundKey != nil || foundValue != nil {
@@ -396,9 +396,9 @@ func TestMapChaining(t *testing.T) {
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
-	chainedMap := m.Select(func(key interface{}, value interface{}) bool {
+	chainedMap := m.Select(func(key any, value any) bool {
 		return value.(int) > 1
-	}).Map(func(key interface{}, value interface{}) (interface{}, interface{}) {
+	}).Map(func(key any, value any) (any, any) {
 		return key.(string) + key.(string), value.(int) * value.(int)
 	})
 	if actualValue := chainedMap.Size(); actualValue != 2 {
@@ -568,7 +568,7 @@ func TestMapIteratorLast(t *testing.T) {
 
 func TestMapIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -620,7 +620,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 func TestMapIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -702,7 +702,7 @@ func TestMapSerialization(t *testing.T) {
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
 
-	_, err := json.Marshal([]interface{}{"a", "b", "c", m})
+	_, err := json.Marshal([]any{"a", "b", "c", m})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}
@@ -721,7 +721,7 @@ func TestMapString(t *testing.T) {
 	}
 }
 
-//noinspection GoBoolExpressions
+// noinspection GoBoolExpressions
 func assertSerialization(m *Map, txt string, t *testing.T) {
 	if actualValue := m.Keys(); false ||
 		actualValue[0].(string) != "a" ||

--- a/queues/arrayqueue/arrayqueue.go
+++ b/queues/arrayqueue/arrayqueue.go
@@ -31,13 +31,13 @@ func New() *Queue {
 }
 
 // Enqueue adds a value to the end of the queue
-func (queue *Queue) Enqueue(value interface{}) {
+func (queue *Queue) Enqueue(value any) {
 	queue.list.Add(value)
 }
 
 // Dequeue removes first element of the queue and returns it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to dequeue.
-func (queue *Queue) Dequeue() (value interface{}, ok bool) {
+func (queue *Queue) Dequeue() (value any, ok bool) {
 	value, ok = queue.list.Get(0)
 	if ok {
 		queue.list.Remove(0)
@@ -47,7 +47,7 @@ func (queue *Queue) Dequeue() (value interface{}, ok bool) {
 
 // Peek returns first element of the queue without removing it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to peek.
-func (queue *Queue) Peek() (value interface{}, ok bool) {
+func (queue *Queue) Peek() (value any, ok bool) {
 	return queue.list.Get(0)
 }
 
@@ -67,7 +67,7 @@ func (queue *Queue) Clear() {
 }
 
 // Values returns all elements in the queue (FIFO order).
-func (queue *Queue) Values() []interface{} {
+func (queue *Queue) Values() []any {
 	return queue.list.Values()
 }
 

--- a/queues/arrayqueue/arrayqueue_test.go
+++ b/queues/arrayqueue/arrayqueue_test.go
@@ -242,7 +242,7 @@ func TestQueueIteratorLast(t *testing.T) {
 
 func TestQueueIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -294,7 +294,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 func TestQueueIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -373,7 +373,7 @@ func TestQueueSerialization(t *testing.T) {
 	err = queue.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", queue})
+	bytes, err = json.Marshal([]any{"a", "b", "c", queue})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/queues/arrayqueue/iterator.go
+++ b/queues/arrayqueue/iterator.go
@@ -43,7 +43,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	value, _ := iterator.queue.list.Get(iterator.index)
 	return value
 }
@@ -86,7 +86,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -100,7 +100,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/queues/circularbuffer/circularbuffer.go
+++ b/queues/circularbuffer/circularbuffer.go
@@ -23,7 +23,7 @@ var _ queues.Queue = (*Queue)(nil)
 
 // Queue holds values in a slice.
 type Queue struct {
-	values  []interface{}
+	values  []any
 	start   int
 	end     int
 	full    bool
@@ -43,7 +43,7 @@ func New(maxSize int) *Queue {
 }
 
 // Enqueue adds a value to the end of the queue
-func (queue *Queue) Enqueue(value interface{}) {
+func (queue *Queue) Enqueue(value any) {
 	if queue.Full() {
 		queue.Dequeue()
 	}
@@ -61,7 +61,7 @@ func (queue *Queue) Enqueue(value interface{}) {
 
 // Dequeue removes first element of the queue and returns it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to dequeue.
-func (queue *Queue) Dequeue() (value interface{}, ok bool) {
+func (queue *Queue) Dequeue() (value any, ok bool) {
 	if queue.Empty() {
 		return nil, false
 	}
@@ -84,7 +84,7 @@ func (queue *Queue) Dequeue() (value interface{}, ok bool) {
 
 // Peek returns first element of the queue without removing it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to peek.
-func (queue *Queue) Peek() (value interface{}, ok bool) {
+func (queue *Queue) Peek() (value any, ok bool) {
 	if queue.Empty() {
 		return nil, false
 	}
@@ -108,7 +108,7 @@ func (queue *Queue) Size() int {
 
 // Clear removes all elements from the queue.
 func (queue *Queue) Clear() {
-	queue.values = make([]interface{}, queue.maxSize, queue.maxSize)
+	queue.values = make([]any, queue.maxSize, queue.maxSize)
 	queue.start = 0
 	queue.end = 0
 	queue.full = false
@@ -116,8 +116,8 @@ func (queue *Queue) Clear() {
 }
 
 // Values returns all elements in the queue (FIFO order).
-func (queue *Queue) Values() []interface{} {
-	values := make([]interface{}, queue.Size(), queue.Size())
+func (queue *Queue) Values() []any {
+	values := make([]any, queue.Size(), queue.Size())
 	for i := 0; i < queue.Size(); i++ {
 		values[i] = queue.values[(queue.start+i)%queue.maxSize]
 	}

--- a/queues/circularbuffer/circularbuffer_test.go
+++ b/queues/circularbuffer/circularbuffer_test.go
@@ -48,7 +48,7 @@ func TestQueuePeek(t *testing.T) {
 }
 
 func TestQueueDequeue(t *testing.T) {
-	assert := func(actualValue interface{}, expectedValue interface{}) {
+	assert := func(actualValue any, expectedValue any) {
 		if actualValue != expectedValue {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
@@ -100,7 +100,7 @@ func TestQueueDequeue(t *testing.T) {
 }
 
 func TestQueueDequeueFull(t *testing.T) {
-	assert := func(actualValue interface{}, expectedValue interface{}) {
+	assert := func(actualValue any, expectedValue any) {
 		if actualValue != expectedValue {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
@@ -319,7 +319,7 @@ func TestQueueIteratorLast(t *testing.T) {
 
 func TestQueueIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -371,7 +371,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 func TestQueueIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -424,7 +424,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 }
 
 func TestQueueIterator(t *testing.T) {
-	assert := func(actualValue interface{}, expectedValue interface{}) {
+	assert := func(actualValue any, expectedValue any) {
 		if actualValue != expectedValue {
 			t.Errorf("Got %v expected %v", actualValue, expectedValue)
 		}
@@ -508,7 +508,7 @@ func TestQueueSerialization(t *testing.T) {
 	err = queue.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", queue})
+	bytes, err = json.Marshal([]any{"a", "b", "c", queue})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/queues/circularbuffer/iterator.go
+++ b/queues/circularbuffer/iterator.go
@@ -43,7 +43,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	index := (iterator.index + iterator.queue.start) % iterator.queue.maxSize
 	value := iterator.queue.values[index]
 	return value
@@ -87,7 +87,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -101,7 +101,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/queues/circularbuffer/serialization.go
+++ b/queues/circularbuffer/serialization.go
@@ -20,7 +20,7 @@ func (queue *Queue) ToJSON() ([]byte, error) {
 
 // FromJSON populates list's elements from the input JSON representation.
 func (queue *Queue) FromJSON(data []byte) error {
-	var values []interface{}
+	var values []any
 	err := json.Unmarshal(data, &values)
 	if err == nil {
 		for _, value := range values {

--- a/queues/linkedlistqueue/iterator.go
+++ b/queues/linkedlistqueue/iterator.go
@@ -33,7 +33,7 @@ func (iterator *Iterator) Next() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	value, _ := iterator.queue.list.Get(iterator.index)
 	return value
 }
@@ -62,7 +62,7 @@ func (iterator *Iterator) First() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/queues/linkedlistqueue/linkedlistqueue.go
+++ b/queues/linkedlistqueue/linkedlistqueue.go
@@ -31,13 +31,13 @@ func New() *Queue {
 }
 
 // Enqueue adds a value to the end of the queue
-func (queue *Queue) Enqueue(value interface{}) {
+func (queue *Queue) Enqueue(value any) {
 	queue.list.Add(value)
 }
 
 // Dequeue removes first element of the queue and returns it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to dequeue.
-func (queue *Queue) Dequeue() (value interface{}, ok bool) {
+func (queue *Queue) Dequeue() (value any, ok bool) {
 	value, ok = queue.list.Get(0)
 	if ok {
 		queue.list.Remove(0)
@@ -47,7 +47,7 @@ func (queue *Queue) Dequeue() (value interface{}, ok bool) {
 
 // Peek returns first element of the queue without removing it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to peek.
-func (queue *Queue) Peek() (value interface{}, ok bool) {
+func (queue *Queue) Peek() (value any, ok bool) {
 	return queue.list.Get(0)
 }
 
@@ -67,7 +67,7 @@ func (queue *Queue) Clear() {
 }
 
 // Values returns all elements in the queue (FIFO order).
-func (queue *Queue) Values() []interface{} {
+func (queue *Queue) Values() []any {
 	return queue.list.Values()
 }
 

--- a/queues/linkedlistqueue/linkedlistqueue_test.go
+++ b/queues/linkedlistqueue/linkedlistqueue_test.go
@@ -159,7 +159,7 @@ func TestQueueIteratorFirst(t *testing.T) {
 
 func TestQueueIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -236,7 +236,7 @@ func TestQueueSerialization(t *testing.T) {
 	err = queue.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", queue})
+	bytes, err = json.Marshal([]any{"a", "b", "c", queue})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/queues/priorityqueue/iterator.go
+++ b/queues/priorityqueue/iterator.go
@@ -39,7 +39,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.iterator.Value()
 }
 
@@ -79,7 +79,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	return iterator.iterator.NextTo(f)
 }
 
@@ -87,6 +87,6 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	return iterator.iterator.PrevTo(f)
 }

--- a/queues/priorityqueue/priorityqueue.go
+++ b/queues/priorityqueue/priorityqueue.go
@@ -38,19 +38,19 @@ func NewWith(comparator utils.Comparator) *Queue {
 }
 
 // Enqueue adds a value to the end of the queue
-func (queue *Queue) Enqueue(value interface{}) {
+func (queue *Queue) Enqueue(value any) {
 	queue.heap.Push(value)
 }
 
 // Dequeue removes first element of the queue and returns it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to dequeue.
-func (queue *Queue) Dequeue() (value interface{}, ok bool) {
+func (queue *Queue) Dequeue() (value any, ok bool) {
 	return queue.heap.Pop()
 }
 
 // Peek returns top element on the queue without removing it, or nil if queue is empty.
 // Second return parameter is true, unless the queue was empty and there was nothing to peek.
-func (queue *Queue) Peek() (value interface{}, ok bool) {
+func (queue *Queue) Peek() (value any, ok bool) {
 	return queue.heap.Peek()
 }
 
@@ -70,7 +70,7 @@ func (queue *Queue) Clear() {
 }
 
 // Values returns all elements in the queue.
-func (queue *Queue) Values() []interface{} {
+func (queue *Queue) Values() []any {
 	return queue.heap.Values()
 }
 

--- a/queues/priorityqueue/priorityqueue_test.go
+++ b/queues/priorityqueue/priorityqueue_test.go
@@ -23,7 +23,7 @@ func (element Element) String() string {
 }
 
 // Comparator function (sort by priority value in descending order)
-func byPriority(a, b interface{}) int {
+func byPriority(a, b any) int {
 	return -utils.IntComparator( // Note "-" for descending order
 		a.(Element).priority,
 		b.(Element).priority,
@@ -319,7 +319,7 @@ func TestBinaryQueueIteratorLast(t *testing.T) {
 
 func TestBinaryQueueIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -371,7 +371,7 @@ func TestBinaryQueueIteratorNextTo(t *testing.T) {
 
 func TestBinaryQueueIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -454,7 +454,7 @@ func TestBinaryQueueSerialization(t *testing.T) {
 	err = queue.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", queue})
+	bytes, err = json.Marshal([]any{"a", "b", "c", queue})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/queues/queues.go
+++ b/queues/queues.go
@@ -14,9 +14,9 @@ import "github.com/emirpasic/gods/containers"
 
 // Queue interface that all queues implement
 type Queue interface {
-	Enqueue(value interface{})
-	Dequeue() (value interface{}, ok bool)
-	Peek() (value interface{}, ok bool)
+	Enqueue(value any)
+	Dequeue() (value any, ok bool)
+	Peek() (value any, ok bool)
 
 	containers.Container
 	// Empty() bool

--- a/sets/hashset/hashset.go
+++ b/sets/hashset/hashset.go
@@ -20,14 +20,14 @@ var _ sets.Set = (*Set)(nil)
 
 // Set holds elements in go's native map
 type Set struct {
-	items map[interface{}]struct{}
+	items map[any]struct{}
 }
 
 var itemExists = struct{}{}
 
 // New instantiates a new empty set and adds the passed values, if any, to the set
-func New(values ...interface{}) *Set {
-	set := &Set{items: make(map[interface{}]struct{})}
+func New(values ...any) *Set {
+	set := &Set{items: make(map[any]struct{})}
 	if len(values) > 0 {
 		set.Add(values...)
 	}
@@ -35,14 +35,14 @@ func New(values ...interface{}) *Set {
 }
 
 // Add adds the items (one or more) to the set.
-func (set *Set) Add(items ...interface{}) {
+func (set *Set) Add(items ...any) {
 	for _, item := range items {
 		set.items[item] = itemExists
 	}
 }
 
 // Remove removes the items (one or more) from the set.
-func (set *Set) Remove(items ...interface{}) {
+func (set *Set) Remove(items ...any) {
 	for _, item := range items {
 		delete(set.items, item)
 	}
@@ -51,7 +51,7 @@ func (set *Set) Remove(items ...interface{}) {
 // Contains check if items (one or more) are present in the set.
 // All items have to be present in the set for the method to return true.
 // Returns true if no arguments are passed at all, i.e. set is always superset of empty set.
-func (set *Set) Contains(items ...interface{}) bool {
+func (set *Set) Contains(items ...any) bool {
 	for _, item := range items {
 		if _, contains := set.items[item]; !contains {
 			return false
@@ -72,12 +72,12 @@ func (set *Set) Size() int {
 
 // Clear clears all values in the set.
 func (set *Set) Clear() {
-	set.items = make(map[interface{}]struct{})
+	set.items = make(map[any]struct{})
 }
 
 // Values returns all items in the set.
-func (set *Set) Values() []interface{} {
-	values := make([]interface{}, set.Size())
+func (set *Set) Values() []any {
+	values := make([]any, set.Size())
 	count := 0
 	for item := range set.items {
 		values[count] = item

--- a/sets/hashset/hashset_test.go
+++ b/sets/hashset/hashset_test.go
@@ -106,7 +106,7 @@ func TestSetSerialization(t *testing.T) {
 	err = set.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", set})
+	bytes, err = json.Marshal([]any{"a", "b", "c", set})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/sets/hashset/serialization.go
+++ b/sets/hashset/serialization.go
@@ -20,7 +20,7 @@ func (set *Set) ToJSON() ([]byte, error) {
 
 // FromJSON populates the set from the input JSON representation.
 func (set *Set) FromJSON(data []byte) error {
-	elements := []interface{}{}
+	elements := []any{}
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		set.Clear()

--- a/sets/linkedhashset/enumerable.go
+++ b/sets/linkedhashset/enumerable.go
@@ -10,7 +10,7 @@ import "github.com/emirpasic/gods/containers"
 var _ containers.EnumerableWithIndex = (*Set)(nil)
 
 // Each calls the given function once for each element, passing that element's index and value.
-func (set *Set) Each(f func(index int, value interface{})) {
+func (set *Set) Each(f func(index int, value any)) {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		f(iterator.Index(), iterator.Value())
@@ -19,7 +19,7 @@ func (set *Set) Each(f func(index int, value interface{})) {
 
 // Map invokes the given function once for each element and returns a
 // container containing the values returned by the given function.
-func (set *Set) Map(f func(index int, value interface{}) interface{}) *Set {
+func (set *Set) Map(f func(index int, value any) any) *Set {
 	newSet := New()
 	iterator := set.Iterator()
 	for iterator.Next() {
@@ -29,7 +29,7 @@ func (set *Set) Map(f func(index int, value interface{}) interface{}) *Set {
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (set *Set) Select(f func(index int, value interface{}) bool) *Set {
+func (set *Set) Select(f func(index int, value any) bool) *Set {
 	newSet := New()
 	iterator := set.Iterator()
 	for iterator.Next() {
@@ -42,7 +42,7 @@ func (set *Set) Select(f func(index int, value interface{}) bool) *Set {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (set *Set) Any(f func(index int, value interface{}) bool) bool {
+func (set *Set) Any(f func(index int, value any) bool) bool {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {
@@ -54,7 +54,7 @@ func (set *Set) Any(f func(index int, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (set *Set) All(f func(index int, value interface{}) bool) bool {
+func (set *Set) All(f func(index int, value any) bool) bool {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Index(), iterator.Value()) {
@@ -67,7 +67,7 @@ func (set *Set) All(f func(index int, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (index,value) for which the function is true or -1,nil otherwise
 // if no element matches the criteria.
-func (set *Set) Find(f func(index int, value interface{}) bool) (int, interface{}) {
+func (set *Set) Find(f func(index int, value any) bool) (int, any) {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {

--- a/sets/linkedhashset/iterator.go
+++ b/sets/linkedhashset/iterator.go
@@ -39,7 +39,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.iterator.Value()
 }
 
@@ -79,7 +79,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -93,7 +93,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/sets/linkedhashset/linkedhashset.go
+++ b/sets/linkedhashset/linkedhashset.go
@@ -25,16 +25,16 @@ var _ sets.Set = (*Set)(nil)
 
 // Set holds elements in go's native map
 type Set struct {
-	table    map[interface{}]struct{}
+	table    map[any]struct{}
 	ordering *doublylinkedlist.List
 }
 
 var itemExists = struct{}{}
 
 // New instantiates a new empty set and adds the passed values, if any, to the set
-func New(values ...interface{}) *Set {
+func New(values ...any) *Set {
 	set := &Set{
-		table:    make(map[interface{}]struct{}),
+		table:    make(map[any]struct{}),
 		ordering: doublylinkedlist.New(),
 	}
 	if len(values) > 0 {
@@ -45,7 +45,7 @@ func New(values ...interface{}) *Set {
 
 // Add adds the items (one or more) to the set.
 // Note that insertion-order is not affected if an element is re-inserted into the set.
-func (set *Set) Add(items ...interface{}) {
+func (set *Set) Add(items ...any) {
 	for _, item := range items {
 		if _, contains := set.table[item]; !contains {
 			set.table[item] = itemExists
@@ -56,7 +56,7 @@ func (set *Set) Add(items ...interface{}) {
 
 // Remove removes the items (one or more) from the set.
 // Slow operation, worst-case O(n^2).
-func (set *Set) Remove(items ...interface{}) {
+func (set *Set) Remove(items ...any) {
 	for _, item := range items {
 		if _, contains := set.table[item]; contains {
 			delete(set.table, item)
@@ -69,7 +69,7 @@ func (set *Set) Remove(items ...interface{}) {
 // Contains check if items (one or more) are present in the set.
 // All items have to be present in the set for the method to return true.
 // Returns true if no arguments are passed at all, i.e. set is always superset of empty set.
-func (set *Set) Contains(items ...interface{}) bool {
+func (set *Set) Contains(items ...any) bool {
 	for _, item := range items {
 		if _, contains := set.table[item]; !contains {
 			return false
@@ -90,13 +90,13 @@ func (set *Set) Size() int {
 
 // Clear clears all values in the set.
 func (set *Set) Clear() {
-	set.table = make(map[interface{}]struct{})
+	set.table = make(map[any]struct{})
 	set.ordering.Clear()
 }
 
 // Values returns all items in the set.
-func (set *Set) Values() []interface{} {
-	values := make([]interface{}, set.Size())
+func (set *Set) Values() []any {
+	values := make([]any, set.Size())
 	it := set.Iterator()
 	for it.Next() {
 		values[it.Index()] = it.Value()

--- a/sets/linkedhashset/linkedhashset_test.go
+++ b/sets/linkedhashset/linkedhashset_test.go
@@ -82,7 +82,7 @@ func TestSetRemove(t *testing.T) {
 func TestSetEach(t *testing.T) {
 	set := New()
 	set.Add("c", "a", "b")
-	set.Each(func(index int, value interface{}) {
+	set.Each(func(index int, value any) {
 		switch index {
 		case 0:
 			if actualValue, expectedValue := value, "c"; actualValue != expectedValue {
@@ -105,7 +105,7 @@ func TestSetEach(t *testing.T) {
 func TestSetMap(t *testing.T) {
 	set := New()
 	set.Add("c", "a", "b")
-	mappedSet := set.Map(func(index int, value interface{}) interface{} {
+	mappedSet := set.Map(func(index int, value any) any {
 		return "mapped: " + value.(string)
 	})
 	if actualValue, expectedValue := mappedSet.Contains("mapped: c", "mapped: b", "mapped: a"), true; actualValue != expectedValue {
@@ -122,7 +122,7 @@ func TestSetMap(t *testing.T) {
 func TestSetSelect(t *testing.T) {
 	set := New()
 	set.Add("c", "a", "b")
-	selectedSet := set.Select(func(index int, value interface{}) bool {
+	selectedSet := set.Select(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if actualValue, expectedValue := selectedSet.Contains("a", "b"), true; actualValue != expectedValue {
@@ -140,13 +140,13 @@ func TestSetSelect(t *testing.T) {
 func TestSetAny(t *testing.T) {
 	set := New()
 	set.Add("c", "a", "b")
-	any := set.Any(func(index int, value interface{}) bool {
+	any := set.Any(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = set.Any(func(index int, value interface{}) bool {
+	any = set.Any(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if any != false {
@@ -157,13 +157,13 @@ func TestSetAny(t *testing.T) {
 func TestSetAll(t *testing.T) {
 	set := New()
 	set.Add("c", "a", "b")
-	all := set.All(func(index int, value interface{}) bool {
+	all := set.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = set.All(func(index int, value interface{}) bool {
+	all = set.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if all != false {
@@ -174,13 +174,13 @@ func TestSetAll(t *testing.T) {
 func TestSetFind(t *testing.T) {
 	set := New()
 	set.Add("c", "a", "b")
-	foundIndex, foundValue := set.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue := set.Find(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if foundValue != "c" || foundIndex != 0 {
 		t.Errorf("Got %v at %v expected %v at %v", foundValue, foundIndex, "c", 0)
 	}
-	foundIndex, foundValue = set.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue = set.Find(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if foundValue != nil || foundIndex != -1 {
@@ -336,7 +336,7 @@ func TestSetIteratorLast(t *testing.T) {
 
 func TestSetIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -385,7 +385,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 func TestSetIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -459,7 +459,7 @@ func TestSetSerialization(t *testing.T) {
 	err = set.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", set})
+	bytes, err = json.Marshal([]any{"a", "b", "c", set})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/sets/linkedhashset/serialization.go
+++ b/sets/linkedhashset/serialization.go
@@ -20,7 +20,7 @@ func (set *Set) ToJSON() ([]byte, error) {
 
 // FromJSON populates the set from the input JSON representation.
 func (set *Set) FromJSON(data []byte) error {
-	elements := []interface{}{}
+	elements := []any{}
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		set.Clear()

--- a/sets/sets.go
+++ b/sets/sets.go
@@ -13,9 +13,9 @@ import "github.com/emirpasic/gods/containers"
 
 // Set interface that all sets implement
 type Set interface {
-	Add(elements ...interface{})
-	Remove(elements ...interface{})
-	Contains(elements ...interface{}) bool
+	Add(elements ...any)
+	Remove(elements ...any)
+	Contains(elements ...any) bool
 	// Intersection(another *Set) *Set
 	// Union(another *Set) *Set
 	// Difference(another *Set) *Set

--- a/sets/treeset/enumerable.go
+++ b/sets/treeset/enumerable.go
@@ -13,7 +13,7 @@ import (
 var _ containers.EnumerableWithIndex = (*Set)(nil)
 
 // Each calls the given function once for each element, passing that element's index and value.
-func (set *Set) Each(f func(index int, value interface{})) {
+func (set *Set) Each(f func(index int, value any)) {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		f(iterator.Index(), iterator.Value())
@@ -22,7 +22,7 @@ func (set *Set) Each(f func(index int, value interface{})) {
 
 // Map invokes the given function once for each element and returns a
 // container containing the values returned by the given function.
-func (set *Set) Map(f func(index int, value interface{}) interface{}) *Set {
+func (set *Set) Map(f func(index int, value any) any) *Set {
 	newSet := &Set{tree: rbt.NewWith(set.tree.Comparator)}
 	iterator := set.Iterator()
 	for iterator.Next() {
@@ -32,7 +32,7 @@ func (set *Set) Map(f func(index int, value interface{}) interface{}) *Set {
 }
 
 // Select returns a new container containing all elements for which the given function returns a true value.
-func (set *Set) Select(f func(index int, value interface{}) bool) *Set {
+func (set *Set) Select(f func(index int, value any) bool) *Set {
 	newSet := &Set{tree: rbt.NewWith(set.tree.Comparator)}
 	iterator := set.Iterator()
 	for iterator.Next() {
@@ -45,7 +45,7 @@ func (set *Set) Select(f func(index int, value interface{}) bool) *Set {
 
 // Any passes each element of the container to the given function and
 // returns true if the function ever returns true for any element.
-func (set *Set) Any(f func(index int, value interface{}) bool) bool {
+func (set *Set) Any(f func(index int, value any) bool) bool {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {
@@ -57,7 +57,7 @@ func (set *Set) Any(f func(index int, value interface{}) bool) bool {
 
 // All passes each element of the container to the given function and
 // returns true if the function returns true for all elements.
-func (set *Set) All(f func(index int, value interface{}) bool) bool {
+func (set *Set) All(f func(index int, value any) bool) bool {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if !f(iterator.Index(), iterator.Value()) {
@@ -70,7 +70,7 @@ func (set *Set) All(f func(index int, value interface{}) bool) bool {
 // Find passes each element of the container to the given function and returns
 // the first (index,value) for which the function is true or -1,nil otherwise
 // if no element matches the criteria.
-func (set *Set) Find(f func(index int, value interface{}) bool) (int, interface{}) {
+func (set *Set) Find(f func(index int, value any) bool) (int, any) {
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {

--- a/sets/treeset/iterator.go
+++ b/sets/treeset/iterator.go
@@ -47,7 +47,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.iterator.Key()
 }
 
@@ -91,7 +91,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -105,7 +105,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/sets/treeset/serialization.go
+++ b/sets/treeset/serialization.go
@@ -20,7 +20,7 @@ func (set *Set) ToJSON() ([]byte, error) {
 
 // FromJSON populates the set from the input JSON representation.
 func (set *Set) FromJSON(data []byte) error {
-	elements := []interface{}{}
+	elements := []any{}
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		set.Clear()

--- a/sets/treeset/treeset.go
+++ b/sets/treeset/treeset.go
@@ -29,7 +29,7 @@ type Set struct {
 var itemExists = struct{}{}
 
 // NewWith instantiates a new empty set with the custom comparator.
-func NewWith(comparator utils.Comparator, values ...interface{}) *Set {
+func NewWith(comparator utils.Comparator, values ...any) *Set {
 	set := &Set{tree: rbt.NewWith(comparator)}
 	if len(values) > 0 {
 		set.Add(values...)
@@ -38,7 +38,7 @@ func NewWith(comparator utils.Comparator, values ...interface{}) *Set {
 }
 
 // NewWithIntComparator instantiates a new empty set with the IntComparator, i.e. keys are of type int.
-func NewWithIntComparator(values ...interface{}) *Set {
+func NewWithIntComparator(values ...any) *Set {
 	set := &Set{tree: rbt.NewWithIntComparator()}
 	if len(values) > 0 {
 		set.Add(values...)
@@ -47,7 +47,7 @@ func NewWithIntComparator(values ...interface{}) *Set {
 }
 
 // NewWithStringComparator instantiates a new empty set with the StringComparator, i.e. keys are of type string.
-func NewWithStringComparator(values ...interface{}) *Set {
+func NewWithStringComparator(values ...any) *Set {
 	set := &Set{tree: rbt.NewWithStringComparator()}
 	if len(values) > 0 {
 		set.Add(values...)
@@ -56,14 +56,14 @@ func NewWithStringComparator(values ...interface{}) *Set {
 }
 
 // Add adds the items (one or more) to the set.
-func (set *Set) Add(items ...interface{}) {
+func (set *Set) Add(items ...any) {
 	for _, item := range items {
 		set.tree.Put(item, itemExists)
 	}
 }
 
 // Remove removes the items (one or more) from the set.
-func (set *Set) Remove(items ...interface{}) {
+func (set *Set) Remove(items ...any) {
 	for _, item := range items {
 		set.tree.Remove(item)
 	}
@@ -72,7 +72,7 @@ func (set *Set) Remove(items ...interface{}) {
 // Contains checks weather items (one or more) are present in the set.
 // All items have to be present in the set for the method to return true.
 // Returns true if no arguments are passed at all, i.e. set is always superset of empty set.
-func (set *Set) Contains(items ...interface{}) bool {
+func (set *Set) Contains(items ...any) bool {
 	for _, item := range items {
 		if _, contains := set.tree.Get(item); !contains {
 			return false
@@ -97,7 +97,7 @@ func (set *Set) Clear() {
 }
 
 // Values returns all items in the set.
-func (set *Set) Values() []interface{} {
+func (set *Set) Values() []any {
 	return set.tree.Keys()
 }
 

--- a/sets/treeset/treeset_test.go
+++ b/sets/treeset/treeset_test.go
@@ -83,7 +83,7 @@ func TestSetRemove(t *testing.T) {
 func TestSetEach(t *testing.T) {
 	set := NewWithStringComparator()
 	set.Add("c", "a", "b")
-	set.Each(func(index int, value interface{}) {
+	set.Each(func(index int, value any) {
 		switch index {
 		case 0:
 			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
@@ -106,7 +106,7 @@ func TestSetEach(t *testing.T) {
 func TestSetMap(t *testing.T) {
 	set := NewWithStringComparator()
 	set.Add("c", "a", "b")
-	mappedSet := set.Map(func(index int, value interface{}) interface{} {
+	mappedSet := set.Map(func(index int, value any) any {
 		return "mapped: " + value.(string)
 	})
 	if actualValue, expectedValue := mappedSet.Contains("mapped: a", "mapped: b", "mapped: c"), true; actualValue != expectedValue {
@@ -123,7 +123,7 @@ func TestSetMap(t *testing.T) {
 func TestSetSelect(t *testing.T) {
 	set := NewWithStringComparator()
 	set.Add("c", "a", "b")
-	selectedSet := set.Select(func(index int, value interface{}) bool {
+	selectedSet := set.Select(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if actualValue, expectedValue := selectedSet.Contains("a", "b"), true; actualValue != expectedValue {
@@ -141,13 +141,13 @@ func TestSetSelect(t *testing.T) {
 func TestSetAny(t *testing.T) {
 	set := NewWithStringComparator()
 	set.Add("c", "a", "b")
-	any := set.Any(func(index int, value interface{}) bool {
+	any := set.Any(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if any != true {
 		t.Errorf("Got %v expected %v", any, true)
 	}
-	any = set.Any(func(index int, value interface{}) bool {
+	any = set.Any(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if any != false {
@@ -158,13 +158,13 @@ func TestSetAny(t *testing.T) {
 func TestSetAll(t *testing.T) {
 	set := NewWithStringComparator()
 	set.Add("c", "a", "b")
-	all := set.All(func(index int, value interface{}) bool {
+	all := set.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "c"
 	})
 	if all != true {
 		t.Errorf("Got %v expected %v", all, true)
 	}
-	all = set.All(func(index int, value interface{}) bool {
+	all = set.All(func(index int, value any) bool {
 		return value.(string) >= "a" && value.(string) <= "b"
 	})
 	if all != false {
@@ -175,13 +175,13 @@ func TestSetAll(t *testing.T) {
 func TestSetFind(t *testing.T) {
 	set := NewWithStringComparator()
 	set.Add("c", "a", "b")
-	foundIndex, foundValue := set.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue := set.Find(func(index int, value any) bool {
 		return value.(string) == "c"
 	})
 	if foundValue != "c" || foundIndex != 2 {
 		t.Errorf("Got %v at %v expected %v at %v", foundValue, foundIndex, "c", 2)
 	}
-	foundIndex, foundValue = set.Find(func(index int, value interface{}) bool {
+	foundIndex, foundValue = set.Find(func(index int, value any) bool {
 		return value.(string) == "x"
 	})
 	if foundValue != nil || foundIndex != -1 {
@@ -345,7 +345,7 @@ func TestSetIteratorLast(t *testing.T) {
 
 func TestSetIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -394,7 +394,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 func TestSetIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -468,7 +468,7 @@ func TestSetSerialization(t *testing.T) {
 	err = set.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", set})
+	bytes, err = json.Marshal([]any{"a", "b", "c", set})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/stacks/arraystack/arraystack.go
+++ b/stacks/arraystack/arraystack.go
@@ -30,13 +30,13 @@ func New() *Stack {
 }
 
 // Push adds a value onto the top of the stack
-func (stack *Stack) Push(value interface{}) {
+func (stack *Stack) Push(value any) {
 	stack.list.Add(value)
 }
 
 // Pop removes top element on stack and returns it, or nil if stack is empty.
 // Second return parameter is true, unless the stack was empty and there was nothing to pop.
-func (stack *Stack) Pop() (value interface{}, ok bool) {
+func (stack *Stack) Pop() (value any, ok bool) {
 	value, ok = stack.list.Get(stack.list.Size() - 1)
 	stack.list.Remove(stack.list.Size() - 1)
 	return
@@ -44,7 +44,7 @@ func (stack *Stack) Pop() (value interface{}, ok bool) {
 
 // Peek returns top element on the stack without removing it, or nil if stack is empty.
 // Second return parameter is true, unless the stack was empty and there was nothing to peek.
-func (stack *Stack) Peek() (value interface{}, ok bool) {
+func (stack *Stack) Peek() (value any, ok bool) {
 	return stack.list.Get(stack.list.Size() - 1)
 }
 
@@ -64,9 +64,9 @@ func (stack *Stack) Clear() {
 }
 
 // Values returns all elements in the stack (LIFO order).
-func (stack *Stack) Values() []interface{} {
+func (stack *Stack) Values() []any {
 	size := stack.list.Size()
-	elements := make([]interface{}, size, size)
+	elements := make([]any, size, size)
 	for i := 1; i <= size; i++ {
 		elements[size-i], _ = stack.list.Get(i - 1) // in reverse (LIFO)
 	}

--- a/stacks/arraystack/arraystack_test.go
+++ b/stacks/arraystack/arraystack_test.go
@@ -242,7 +242,7 @@ func TestStackIteratorLast(t *testing.T) {
 
 func TestStackIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -294,7 +294,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 func TestStackIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -373,7 +373,7 @@ func TestStackSerialization(t *testing.T) {
 	err = stack.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", stack})
+	bytes, err = json.Marshal([]any{"a", "b", "c", stack})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/stacks/arraystack/iterator.go
+++ b/stacks/arraystack/iterator.go
@@ -43,7 +43,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	value, _ := iterator.stack.list.Get(iterator.stack.list.Size() - iterator.index - 1) // in reverse (LIFO)
 	return value
 }
@@ -86,7 +86,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -100,7 +100,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/stacks/linkedliststack/iterator.go
+++ b/stacks/linkedliststack/iterator.go
@@ -33,7 +33,7 @@ func (iterator *Iterator) Next() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	value, _ := iterator.stack.list.Get(iterator.index) // in reverse (LIFO)
 	return value
 }
@@ -62,7 +62,7 @@ func (iterator *Iterator) First() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/stacks/linkedliststack/linkedliststack.go
+++ b/stacks/linkedliststack/linkedliststack.go
@@ -30,13 +30,13 @@ func New() *Stack {
 }
 
 // Push adds a value onto the top of the stack
-func (stack *Stack) Push(value interface{}) {
+func (stack *Stack) Push(value any) {
 	stack.list.Prepend(value)
 }
 
 // Pop removes top element on stack and returns it, or nil if stack is empty.
 // Second return parameter is true, unless the stack was empty and there was nothing to pop.
-func (stack *Stack) Pop() (value interface{}, ok bool) {
+func (stack *Stack) Pop() (value any, ok bool) {
 	value, ok = stack.list.Get(0)
 	stack.list.Remove(0)
 	return
@@ -44,7 +44,7 @@ func (stack *Stack) Pop() (value interface{}, ok bool) {
 
 // Peek returns top element on the stack without removing it, or nil if stack is empty.
 // Second return parameter is true, unless the stack was empty and there was nothing to peek.
-func (stack *Stack) Peek() (value interface{}, ok bool) {
+func (stack *Stack) Peek() (value any, ok bool) {
 	return stack.list.Get(0)
 }
 
@@ -64,7 +64,7 @@ func (stack *Stack) Clear() {
 }
 
 // Values returns all elements in the stack (LIFO order).
-func (stack *Stack) Values() []interface{} {
+func (stack *Stack) Values() []any {
 	return stack.list.Values()
 }
 

--- a/stacks/linkedliststack/linkedliststack_test.go
+++ b/stacks/linkedliststack/linkedliststack_test.go
@@ -152,7 +152,7 @@ func TestStackIteratorFirst(t *testing.T) {
 
 func TestStackIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -229,7 +229,7 @@ func TestStackSerialization(t *testing.T) {
 	err = stack.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", stack})
+	bytes, err = json.Marshal([]any{"a", "b", "c", stack})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/stacks/stacks.go
+++ b/stacks/stacks.go
@@ -13,9 +13,9 @@ import "github.com/emirpasic/gods/containers"
 
 // Stack interface that all stacks implement
 type Stack interface {
-	Push(value interface{})
-	Pop() (value interface{}, ok bool)
-	Peek() (value interface{}, ok bool)
+	Push(value any)
+	Pop() (value any, ok bool)
+	Peek() (value any, ok bool)
 
 	containers.Container
 	// Empty() bool

--- a/trees/avltree/avltree.go
+++ b/trees/avltree/avltree.go
@@ -27,8 +27,8 @@ type Tree struct {
 
 // Node is a single element within the tree
 type Node struct {
-	Key      interface{}
-	Value    interface{}
+	Key      any
+	Value    any
 	Parent   *Node    // Parent node
 	Children [2]*Node // Children nodes
 	b        int8
@@ -51,14 +51,14 @@ func NewWithStringComparator() *Tree {
 
 // Put inserts node into the tree.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (t *Tree) Put(key interface{}, value interface{}) {
+func (t *Tree) Put(key any, value any) {
 	t.put(key, value, nil, &t.Root)
 }
 
 // Get searches the node in the tree by key and returns its value or nil if key is not found in tree.
 // Second return parameter is true if key was found, otherwise false.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (t *Tree) Get(key interface{}) (value interface{}, found bool) {
+func (t *Tree) Get(key any) (value any, found bool) {
 	n := t.GetNode(key)
 	if n != nil {
 		return n.Value, true
@@ -68,7 +68,7 @@ func (t *Tree) Get(key interface{}) (value interface{}, found bool) {
 
 // GetNode searches the node in the tree by key and returns its node or nil if key is not found in tree.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (t *Tree) GetNode(key interface{}) *Node {
+func (t *Tree) GetNode(key any) *Node {
 	n := t.Root
 	for n != nil {
 		cmp := t.Comparator(key, n.Key)
@@ -86,7 +86,7 @@ func (t *Tree) GetNode(key interface{}) *Node {
 
 // Remove remove the node from the tree by key.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (t *Tree) Remove(key interface{}) {
+func (t *Tree) Remove(key any) {
 	t.remove(key, &t.Root)
 }
 
@@ -117,8 +117,8 @@ func (n *Node) Size() int {
 }
 
 // Keys returns all keys in-order
-func (t *Tree) Keys() []interface{} {
-	keys := make([]interface{}, t.size)
+func (t *Tree) Keys() []any {
+	keys := make([]any, t.size)
 	it := t.Iterator()
 	for i := 0; it.Next(); i++ {
 		keys[i] = it.Key()
@@ -127,8 +127,8 @@ func (t *Tree) Keys() []interface{} {
 }
 
 // Values returns all values in-order based on the key.
-func (t *Tree) Values() []interface{} {
-	values := make([]interface{}, t.size)
+func (t *Tree) Values() []any {
+	values := make([]any, t.size)
 	it := t.Iterator()
 	for i := 0; it.Next(); i++ {
 		values[i] = it.Value()
@@ -156,7 +156,7 @@ func (t *Tree) Right() *Node {
 // all nodes in the tree is larger than the given node.
 //
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (t *Tree) Floor(key interface{}) (floor *Node, found bool) {
+func (t *Tree) Floor(key any) (floor *Node, found bool) {
 	found = false
 	n := t.Root
 	for n != nil {
@@ -185,7 +185,7 @@ func (t *Tree) Floor(key interface{}) (floor *Node, found bool) {
 // all nodes in the tree is smaller than the given node.
 //
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (t *Tree) Ceiling(key interface{}) (floor *Node, found bool) {
+func (t *Tree) Ceiling(key any) (floor *Node, found bool) {
 	found = false
 	n := t.Root
 	for n != nil {
@@ -225,7 +225,7 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%v", n.Key)
 }
 
-func (t *Tree) put(key interface{}, value interface{}, p *Node, qp **Node) bool {
+func (t *Tree) put(key any, value any, p *Node, qp **Node) bool {
 	q := *qp
 	if q == nil {
 		t.size++
@@ -254,7 +254,7 @@ func (t *Tree) put(key interface{}, value interface{}, p *Node, qp **Node) bool 
 	return false
 }
 
-func (t *Tree) remove(key interface{}, qp **Node) bool {
+func (t *Tree) remove(key any, qp **Node) bool {
 	q := *qp
 	if q == nil {
 		return false
@@ -290,7 +290,7 @@ func (t *Tree) remove(key interface{}, qp **Node) bool {
 	return false
 }
 
-func removeMin(qp **Node, minKey *interface{}, minVal *interface{}) bool {
+func removeMin(qp **Node, minKey *any, minVal *any) bool {
 	q := *qp
 	if q.Children[0] == nil {
 		*minKey = q.Key

--- a/trees/avltree/avltree_test.go
+++ b/trees/avltree/avltree_test.go
@@ -76,7 +76,7 @@ func TestAVLTreePut(t *testing.T) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -126,7 +126,7 @@ func TestAVLTreeRemove(t *testing.T) {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -550,7 +550,7 @@ func TestAVLTreeIteratorLast(t *testing.T) {
 
 func TestAVLTreeIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -602,7 +602,7 @@ func TestAVLTreeIteratorNextTo(t *testing.T) {
 
 func TestAVLTreeIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -685,7 +685,7 @@ func TestAVLTreeSerialization(t *testing.T) {
 	err = tree.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", tree})
+	bytes, err = json.Marshal([]any{"a", "b", "c", tree})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/trees/avltree/iterator.go
+++ b/trees/avltree/iterator.go
@@ -69,7 +69,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	if iterator.node == nil {
 		return nil
 	}
@@ -78,7 +78,7 @@ func (iterator *Iterator) Value() interface{} {
 
 // Key returns the current element's key.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Key() interface{} {
+func (iterator *Iterator) Key() any {
 	if iterator.node == nil {
 		return nil
 	}
@@ -125,7 +125,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(key any, value any) bool) bool {
 	for iterator.Next() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {
@@ -139,7 +139,7 @@ func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(key any, value any) bool) bool {
 	for iterator.Prev() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {

--- a/trees/avltree/serialization.go
+++ b/trees/avltree/serialization.go
@@ -16,7 +16,7 @@ var _ containers.JSONDeserializer = (*Tree)(nil)
 
 // ToJSON outputs the JSON representation of the tree.
 func (tree *Tree) ToJSON() ([]byte, error) {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	it := tree.Iterator()
 	for it.Next() {
 		elements[utils.ToString(it.Key())] = it.Value()
@@ -26,7 +26,7 @@ func (tree *Tree) ToJSON() ([]byte, error) {
 
 // FromJSON populates the tree from the input JSON representation.
 func (tree *Tree) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		tree.Clear()

--- a/trees/binaryheap/binaryheap.go
+++ b/trees/binaryheap/binaryheap.go
@@ -44,7 +44,7 @@ func NewWithStringComparator() *Heap {
 }
 
 // Push adds a value onto the heap and bubbles it up accordingly.
-func (heap *Heap) Push(values ...interface{}) {
+func (heap *Heap) Push(values ...any) {
 	if len(values) == 1 {
 		heap.list.Add(values[0])
 		heap.bubbleUp()
@@ -62,7 +62,7 @@ func (heap *Heap) Push(values ...interface{}) {
 
 // Pop removes top element on heap and returns it, or nil if heap is empty.
 // Second return parameter is true, unless the heap was empty and there was nothing to pop.
-func (heap *Heap) Pop() (value interface{}, ok bool) {
+func (heap *Heap) Pop() (value any, ok bool) {
 	value, ok = heap.list.Get(0)
 	if !ok {
 		return
@@ -76,7 +76,7 @@ func (heap *Heap) Pop() (value interface{}, ok bool) {
 
 // Peek returns top element on the heap without removing it, or nil if heap is empty.
 // Second return parameter is true, unless the heap was empty and there was nothing to peek.
-func (heap *Heap) Peek() (value interface{}, ok bool) {
+func (heap *Heap) Peek() (value any, ok bool) {
 	return heap.list.Get(0)
 }
 
@@ -96,8 +96,8 @@ func (heap *Heap) Clear() {
 }
 
 // Values returns all elements in the heap.
-func (heap *Heap) Values() []interface{} {
-	values := make([]interface{}, heap.list.Size(), heap.list.Size())
+func (heap *Heap) Values() []any {
+	values := make([]any, heap.list.Size(), heap.list.Size())
 	for it := heap.Iterator(); it.Next(); {
 		values[it.Index()] = it.Value()
 	}

--- a/trees/binaryheap/binaryheap_test.go
+++ b/trees/binaryheap/binaryheap_test.go
@@ -263,7 +263,7 @@ func TestBinaryHeapIteratorLast(t *testing.T) {
 
 func TestBinaryHeapIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -315,7 +315,7 @@ func TestBinaryHeapIteratorNextTo(t *testing.T) {
 
 func TestBinaryHeapIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index int, value interface{}) bool {
+	seek := func(index int, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -398,7 +398,7 @@ func TestBinaryHeapSerialization(t *testing.T) {
 	err = heap.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", heap})
+	bytes, err = json.Marshal([]any{"a", "b", "c", heap})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/trees/binaryheap/iterator.go
+++ b/trees/binaryheap/iterator.go
@@ -45,7 +45,7 @@ func (iterator *Iterator) Prev() bool {
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	start, end := evaluateRange(iterator.index)
 	if end > iterator.heap.Size() {
 		end = iterator.heap.Size()
@@ -100,7 +100,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(index int, value any) bool) bool {
 	for iterator.Next() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {
@@ -114,7 +114,7 @@ func (iterator *Iterator) NextTo(f func(index int, value interface{}) bool) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's index and value can be retrieved by Index() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(index int, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(index int, value any) bool) bool {
 	for iterator.Prev() {
 		index, value := iterator.Index(), iterator.Value()
 		if f(index, value) {

--- a/trees/btree/btree.go
+++ b/trees/btree/btree.go
@@ -44,8 +44,8 @@ type Node struct {
 
 // Entry represents the key-value pair contained within nodes
 type Entry struct {
-	Key   interface{}
-	Value interface{}
+	Key   any
+	Value any
 }
 
 // NewWith instantiates a B-tree with the order (maximum number of children) and a custom key comparator.
@@ -69,7 +69,7 @@ func NewWithStringComparator(order int) *Tree {
 // Put inserts key-value pair node into the tree.
 // If key already exists, then its value is updated with the new value.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Put(key interface{}, value interface{}) {
+func (tree *Tree) Put(key any, value any) {
 	entry := &Entry{Key: key, Value: value}
 
 	if tree.Root == nil {
@@ -86,7 +86,7 @@ func (tree *Tree) Put(key interface{}, value interface{}) {
 // Get searches the node in the tree by key and returns its value or nil if key is not found in tree.
 // Second return parameter is true if key was found, otherwise false.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Get(key interface{}) (value interface{}, found bool) {
+func (tree *Tree) Get(key any) (value any, found bool) {
 	node, index, found := tree.searchRecursively(tree.Root, key)
 	if found {
 		return node.Entries[index].Value, true
@@ -96,14 +96,14 @@ func (tree *Tree) Get(key interface{}) (value interface{}, found bool) {
 
 // GetNode searches the node in the tree by key and returns its node or nil if key is not found in tree.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) GetNode(key interface{}) *Node {
+func (tree *Tree) GetNode(key any) *Node {
 	node, _, _ := tree.searchRecursively(tree.Root, key)
 	return node
 }
 
 // Remove remove the node from the tree by key.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Remove(key interface{}) {
+func (tree *Tree) Remove(key any) {
 	node, index, found := tree.searchRecursively(tree.Root, key)
 	if found {
 		tree.delete(node, index)
@@ -135,8 +135,8 @@ func (node *Node) Size() int {
 }
 
 // Keys returns all keys in-order
-func (tree *Tree) Keys() []interface{} {
-	keys := make([]interface{}, tree.size)
+func (tree *Tree) Keys() []any {
+	keys := make([]any, tree.size)
 	it := tree.Iterator()
 	for i := 0; it.Next(); i++ {
 		keys[i] = it.Key()
@@ -145,8 +145,8 @@ func (tree *Tree) Keys() []interface{} {
 }
 
 // Values returns all values in-order based on the key.
-func (tree *Tree) Values() []interface{} {
-	values := make([]interface{}, tree.size)
+func (tree *Tree) Values() []any {
+	values := make([]any, tree.size)
 	it := tree.Iterator()
 	for i := 0; it.Next(); i++ {
 		values[i] = it.Value()
@@ -171,7 +171,7 @@ func (tree *Tree) Left() *Node {
 }
 
 // LeftKey returns the left-most (min) key or nil if tree is empty.
-func (tree *Tree) LeftKey() interface{} {
+func (tree *Tree) LeftKey() any {
 	if left := tree.Left(); left != nil {
 		return left.Entries[0].Key
 	}
@@ -179,7 +179,7 @@ func (tree *Tree) LeftKey() interface{} {
 }
 
 // LeftValue returns the left-most value or nil if tree is empty.
-func (tree *Tree) LeftValue() interface{} {
+func (tree *Tree) LeftValue() any {
 	if left := tree.Left(); left != nil {
 		return left.Entries[0].Value
 	}
@@ -192,7 +192,7 @@ func (tree *Tree) Right() *Node {
 }
 
 // RightKey returns the right-most (max) key or nil if tree is empty.
-func (tree *Tree) RightKey() interface{} {
+func (tree *Tree) RightKey() any {
 	if right := tree.Right(); right != nil {
 		return right.Entries[len(right.Entries)-1].Key
 	}
@@ -200,7 +200,7 @@ func (tree *Tree) RightKey() interface{} {
 }
 
 // RightValue returns the right-most value or nil if tree is empty.
-func (tree *Tree) RightValue() interface{} {
+func (tree *Tree) RightValue() any {
 	if right := tree.Right(); right != nil {
 		return right.Entries[len(right.Entries)-1].Value
 	}
@@ -277,7 +277,7 @@ func (tree *Tree) middle() int {
 }
 
 // search searches only within the single node among its entries
-func (tree *Tree) search(node *Node, key interface{}) (index int, found bool) {
+func (tree *Tree) search(node *Node, key any) (index int, found bool) {
 	low, high := 0, len(node.Entries)-1
 	var mid int
 	for low <= high {
@@ -296,7 +296,7 @@ func (tree *Tree) search(node *Node, key interface{}) (index int, found bool) {
 }
 
 // searchRecursively searches recursively down the tree starting at the startNode
-func (tree *Tree) searchRecursively(startNode *Node, key interface{}) (node *Node, index int, found bool) {
+func (tree *Tree) searchRecursively(startNode *Node, key any) (node *Node, index int, found bool) {
 	if tree.Empty() {
 		return nil, -1, false
 	}
@@ -448,7 +448,7 @@ func (tree *Tree) right(node *Node) *Node {
 
 // leftSibling returns the node's left sibling and child index (in parent) if it exists, otherwise (nil,-1)
 // key is any of keys in node (could even be deleted).
-func (tree *Tree) leftSibling(node *Node, key interface{}) (*Node, int) {
+func (tree *Tree) leftSibling(node *Node, key any) (*Node, int) {
 	if node.Parent != nil {
 		index, _ := tree.search(node.Parent, key)
 		index--
@@ -461,7 +461,7 @@ func (tree *Tree) leftSibling(node *Node, key interface{}) (*Node, int) {
 
 // rightSibling returns the node's right sibling and child index (in parent) if it exists, otherwise (nil,-1)
 // key is any of keys in node (could even be deleted).
-func (tree *Tree) rightSibling(node *Node, key interface{}) (*Node, int) {
+func (tree *Tree) rightSibling(node *Node, key any) (*Node, int) {
 	if node.Parent != nil {
 		index, _ := tree.search(node.Parent, key)
 		index++
@@ -497,7 +497,7 @@ func (tree *Tree) delete(node *Node, index int) {
 
 // rebalance rebalances the tree after deletion if necessary and returns true, otherwise false.
 // Note that we first delete the entry and then call rebalance, thus the passed deleted key as reference.
-func (tree *Tree) rebalance(node *Node, deletedKey interface{}) {
+func (tree *Tree) rebalance(node *Node, deletedKey any) {
 	// check if rebalancing is needed
 	if node == nil || len(node.Entries) >= tree.minEntries() {
 		return

--- a/trees/btree/btree_test.go
+++ b/trees/btree/btree_test.go
@@ -21,7 +21,7 @@ func TestBTreeGet1(t *testing.T) {
 	tree.Put(6, "f")
 	tree.Put(7, "g")
 
-	tests := [][]interface{}{
+	tests := [][]any{
 		{0, nil, false},
 		{1, "a", true},
 		{2, "b", true},
@@ -53,7 +53,7 @@ func TestBTreeGet2(t *testing.T) {
 	tree.Put(2, "b")
 	tree.Put(1, "a")
 
-	tests := [][]interface{}{
+	tests := [][]any{
 		{0, nil, false},
 		{1, "a", true},
 		{2, "b", true},
@@ -1005,7 +1005,7 @@ func TestBTreeSearch(t *testing.T) {
 	{
 		tree := NewWithIntComparator(3)
 		tree.Root = &Node{Entries: []*Entry{}, Children: make([]*Node, 0)}
-		tests := [][]interface{}{
+		tests := [][]any{
 			{0, 0, false},
 		}
 		for _, test := range tests {
@@ -1021,7 +1021,7 @@ func TestBTreeSearch(t *testing.T) {
 	{
 		tree := NewWithIntComparator(3)
 		tree.Root = &Node{Entries: []*Entry{{2, 0}, {4, 1}, {6, 2}}, Children: []*Node{}}
-		tests := [][]interface{}{
+		tests := [][]any{
 			{0, 0, false},
 			{1, 0, false},
 			{2, 0, true},
@@ -1068,7 +1068,7 @@ func assertValidTreeNode(t *testing.T, node *Node, expectedEntries int, expected
 
 func TestBTreeIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -1120,7 +1120,7 @@ func TestBTreeIteratorNextTo(t *testing.T) {
 
 func TestBTreeIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -1202,7 +1202,7 @@ func TestBTreeSerialization(t *testing.T) {
 	err = tree.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", tree})
+	bytes, err = json.Marshal([]any{"a", "b", "c", tree})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/trees/btree/iterator.go
+++ b/trees/btree/iterator.go
@@ -149,13 +149,13 @@ between:
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.entry.Value
 }
 
 // Key returns the current element's key.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Key() interface{} {
+func (iterator *Iterator) Key() any {
 	return iterator.entry.Key
 }
 
@@ -201,7 +201,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(key any, value any) bool) bool {
 	for iterator.Next() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {
@@ -215,7 +215,7 @@ func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(key any, value any) bool) bool {
 	for iterator.Prev() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {

--- a/trees/btree/serialization.go
+++ b/trees/btree/serialization.go
@@ -16,7 +16,7 @@ var _ containers.JSONDeserializer = (*Tree)(nil)
 
 // ToJSON outputs the JSON representation of the tree.
 func (tree *Tree) ToJSON() ([]byte, error) {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	it := tree.Iterator()
 	for it.Next() {
 		elements[utils.ToString(it.Key())] = it.Value()
@@ -26,7 +26,7 @@ func (tree *Tree) ToJSON() ([]byte, error) {
 
 // FromJSON populates the tree from the input JSON representation.
 func (tree *Tree) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		tree.Clear()

--- a/trees/redblacktree/iterator.go
+++ b/trees/redblacktree/iterator.go
@@ -115,13 +115,13 @@ between:
 
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Value() interface{} {
+func (iterator *Iterator) Value() any {
 	return iterator.node.Value
 }
 
 // Key returns the current element's key.
 // Does not modify the state of the iterator.
-func (iterator *Iterator) Key() interface{} {
+func (iterator *Iterator) Key() any {
 	return iterator.node.Key
 }
 
@@ -165,7 +165,7 @@ func (iterator *Iterator) Last() bool {
 // passed function, and returns true if there was a next element in the container.
 // If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) NextTo(f func(key any, value any) bool) bool {
 	for iterator.Next() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {
@@ -179,7 +179,7 @@ func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool
 // passed function, and returns true if there was a next element in the container.
 // If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
 // Modifies the state of the iterator.
-func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+func (iterator *Iterator) PrevTo(f func(key any, value any) bool) bool {
 	for iterator.Prev() {
 		key, value := iterator.Key(), iterator.Value()
 		if f(key, value) {

--- a/trees/redblacktree/redblacktree.go
+++ b/trees/redblacktree/redblacktree.go
@@ -35,8 +35,8 @@ type Tree struct {
 
 // Node is a single element within the tree
 type Node struct {
-	Key    interface{}
-	Value  interface{}
+	Key    any
+	Value  any
 	color  color
 	Left   *Node
 	Right  *Node
@@ -60,7 +60,7 @@ func NewWithStringComparator() *Tree {
 
 // Put inserts node into the tree.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Put(key interface{}, value interface{}) {
+func (tree *Tree) Put(key any, value any) {
 	var insertedNode *Node
 	if tree.Root == nil {
 		// Assert key is of comparator's type for initial tree
@@ -104,7 +104,7 @@ func (tree *Tree) Put(key interface{}, value interface{}) {
 // Get searches the node in the tree by key and returns its value or nil if key is not found in tree.
 // Second return parameter is true if key was found, otherwise false.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Get(key interface{}) (value interface{}, found bool) {
+func (tree *Tree) Get(key any) (value any, found bool) {
 	node := tree.lookup(key)
 	if node != nil {
 		return node.Value, true
@@ -114,13 +114,13 @@ func (tree *Tree) Get(key interface{}) (value interface{}, found bool) {
 
 // GetNode searches the node in the tree by key and returns its node or nil if key is not found in tree.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) GetNode(key interface{}) *Node {
+func (tree *Tree) GetNode(key any) *Node {
 	return tree.lookup(key)
 }
 
 // Remove remove the node from the tree by key.
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Remove(key interface{}) {
+func (tree *Tree) Remove(key any) {
 	var child *Node
 	node := tree.lookup(key)
 	if node == nil {
@@ -177,8 +177,8 @@ func (node *Node) Size() int {
 }
 
 // Keys returns all keys in-order
-func (tree *Tree) Keys() []interface{} {
-	keys := make([]interface{}, tree.size)
+func (tree *Tree) Keys() []any {
+	keys := make([]any, tree.size)
 	it := tree.Iterator()
 	for i := 0; it.Next(); i++ {
 		keys[i] = it.Key()
@@ -187,8 +187,8 @@ func (tree *Tree) Keys() []interface{} {
 }
 
 // Values returns all values in-order based on the key.
-func (tree *Tree) Values() []interface{} {
-	values := make([]interface{}, tree.size)
+func (tree *Tree) Values() []any {
+	values := make([]any, tree.size)
 	it := tree.Iterator()
 	for i := 0; it.Next(); i++ {
 		values[i] = it.Value()
@@ -226,7 +226,7 @@ func (tree *Tree) Right() *Node {
 // all nodes in the tree are larger than the given node.
 //
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Floor(key interface{}) (floor *Node, found bool) {
+func (tree *Tree) Floor(key any) (floor *Node, found bool) {
 	found = false
 	node := tree.Root
 	for node != nil {
@@ -255,7 +255,7 @@ func (tree *Tree) Floor(key interface{}) (floor *Node, found bool) {
 // all nodes in the tree are smaller than the given node.
 //
 // Key should adhere to the comparator's type assertion, otherwise method panics.
-func (tree *Tree) Ceiling(key interface{}) (ceiling *Node, found bool) {
+func (tree *Tree) Ceiling(key any) (ceiling *Node, found bool) {
 	found = false
 	node := tree.Root
 	for node != nil {
@@ -323,7 +323,7 @@ func output(node *Node, prefix string, isTail bool, str *string) {
 	}
 }
 
-func (tree *Tree) lookup(key interface{}) *Node {
+func (tree *Tree) lookup(key any) *Node {
 	node := tree.Root
 	for node != nil {
 		compare := tree.Comparator(key, node.Key)

--- a/trees/redblacktree/redblacktree_test.go
+++ b/trees/redblacktree/redblacktree_test.go
@@ -79,7 +79,7 @@ func TestRedBlackTreePut(t *testing.T) {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	tests1 := [][]interface{}{
+	tests1 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -129,7 +129,7 @@ func TestRedBlackTreeRemove(t *testing.T) {
 		t.Errorf("Got %v expected %v", actualValue, 7)
 	}
 
-	tests2 := [][]interface{}{
+	tests2 := [][]any{
 		{1, "a", true},
 		{2, "b", true},
 		{3, "c", true},
@@ -552,7 +552,7 @@ func TestRedBlackTreeIteratorLast(t *testing.T) {
 
 func TestRedBlackTreeIteratorNextTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -604,7 +604,7 @@ func TestRedBlackTreeIteratorNextTo(t *testing.T) {
 
 func TestRedBlackTreeIteratorPrevTo(t *testing.T) {
 	// Sample seek function, i.e. string starting with "b"
-	seek := func(index interface{}, value interface{}) bool {
+	seek := func(index any, value any) bool {
 		return strings.HasSuffix(value.(string), "b")
 	}
 
@@ -686,7 +686,7 @@ func TestRedBlackTreeSerialization(t *testing.T) {
 	err = tree.FromJSON(bytes)
 	assert()
 
-	bytes, err = json.Marshal([]interface{}{"a", "b", "c", tree})
+	bytes, err = json.Marshal([]any{"a", "b", "c", tree})
 	if err != nil {
 		t.Errorf("Got error %v", err)
 	}

--- a/trees/redblacktree/serialization.go
+++ b/trees/redblacktree/serialization.go
@@ -16,7 +16,7 @@ var _ containers.JSONDeserializer = (*Tree)(nil)
 
 // ToJSON outputs the JSON representation of the tree.
 func (tree *Tree) ToJSON() ([]byte, error) {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	it := tree.Iterator()
 	for it.Next() {
 		elements[utils.ToString(it.Key())] = it.Value()
@@ -26,7 +26,7 @@ func (tree *Tree) ToJSON() ([]byte, error) {
 
 // FromJSON populates the tree from the input JSON representation.
 func (tree *Tree) FromJSON(data []byte) error {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	err := json.Unmarshal(data, &elements)
 	if err == nil {
 		tree.Clear()

--- a/utils/comparator.go
+++ b/utils/comparator.go
@@ -10,13 +10,14 @@ import "time"
 // which will panic if a or b are not of the asserted type.
 //
 // Should return a number:
-//    negative , if a < b
-//    zero     , if a == b
-//    positive , if a > b
-type Comparator func(a, b interface{}) int
+//
+//	negative , if a < b
+//	zero     , if a == b
+//	positive , if a > b
+type Comparator func(a, b any) int
 
 // StringComparator provides a fast comparison on strings
-func StringComparator(a, b interface{}) int {
+func StringComparator(a, b any) int {
 	s1 := a.(string)
 	s2 := b.(string)
 	min := len(s2)
@@ -40,7 +41,7 @@ func StringComparator(a, b interface{}) int {
 }
 
 // IntComparator provides a basic comparison on int
-func IntComparator(a, b interface{}) int {
+func IntComparator(a, b any) int {
 	aAsserted := a.(int)
 	bAsserted := b.(int)
 	switch {
@@ -54,7 +55,7 @@ func IntComparator(a, b interface{}) int {
 }
 
 // Int8Comparator provides a basic comparison on int8
-func Int8Comparator(a, b interface{}) int {
+func Int8Comparator(a, b any) int {
 	aAsserted := a.(int8)
 	bAsserted := b.(int8)
 	switch {
@@ -68,7 +69,7 @@ func Int8Comparator(a, b interface{}) int {
 }
 
 // Int16Comparator provides a basic comparison on int16
-func Int16Comparator(a, b interface{}) int {
+func Int16Comparator(a, b any) int {
 	aAsserted := a.(int16)
 	bAsserted := b.(int16)
 	switch {
@@ -82,7 +83,7 @@ func Int16Comparator(a, b interface{}) int {
 }
 
 // Int32Comparator provides a basic comparison on int32
-func Int32Comparator(a, b interface{}) int {
+func Int32Comparator(a, b any) int {
 	aAsserted := a.(int32)
 	bAsserted := b.(int32)
 	switch {
@@ -96,7 +97,7 @@ func Int32Comparator(a, b interface{}) int {
 }
 
 // Int64Comparator provides a basic comparison on int64
-func Int64Comparator(a, b interface{}) int {
+func Int64Comparator(a, b any) int {
 	aAsserted := a.(int64)
 	bAsserted := b.(int64)
 	switch {
@@ -110,7 +111,7 @@ func Int64Comparator(a, b interface{}) int {
 }
 
 // UIntComparator provides a basic comparison on uint
-func UIntComparator(a, b interface{}) int {
+func UIntComparator(a, b any) int {
 	aAsserted := a.(uint)
 	bAsserted := b.(uint)
 	switch {
@@ -124,7 +125,7 @@ func UIntComparator(a, b interface{}) int {
 }
 
 // UInt8Comparator provides a basic comparison on uint8
-func UInt8Comparator(a, b interface{}) int {
+func UInt8Comparator(a, b any) int {
 	aAsserted := a.(uint8)
 	bAsserted := b.(uint8)
 	switch {
@@ -138,7 +139,7 @@ func UInt8Comparator(a, b interface{}) int {
 }
 
 // UInt16Comparator provides a basic comparison on uint16
-func UInt16Comparator(a, b interface{}) int {
+func UInt16Comparator(a, b any) int {
 	aAsserted := a.(uint16)
 	bAsserted := b.(uint16)
 	switch {
@@ -152,7 +153,7 @@ func UInt16Comparator(a, b interface{}) int {
 }
 
 // UInt32Comparator provides a basic comparison on uint32
-func UInt32Comparator(a, b interface{}) int {
+func UInt32Comparator(a, b any) int {
 	aAsserted := a.(uint32)
 	bAsserted := b.(uint32)
 	switch {
@@ -166,7 +167,7 @@ func UInt32Comparator(a, b interface{}) int {
 }
 
 // UInt64Comparator provides a basic comparison on uint64
-func UInt64Comparator(a, b interface{}) int {
+func UInt64Comparator(a, b any) int {
 	aAsserted := a.(uint64)
 	bAsserted := b.(uint64)
 	switch {
@@ -180,7 +181,7 @@ func UInt64Comparator(a, b interface{}) int {
 }
 
 // Float32Comparator provides a basic comparison on float32
-func Float32Comparator(a, b interface{}) int {
+func Float32Comparator(a, b any) int {
 	aAsserted := a.(float32)
 	bAsserted := b.(float32)
 	switch {
@@ -194,7 +195,7 @@ func Float32Comparator(a, b interface{}) int {
 }
 
 // Float64Comparator provides a basic comparison on float64
-func Float64Comparator(a, b interface{}) int {
+func Float64Comparator(a, b any) int {
 	aAsserted := a.(float64)
 	bAsserted := b.(float64)
 	switch {
@@ -208,7 +209,7 @@ func Float64Comparator(a, b interface{}) int {
 }
 
 // ByteComparator provides a basic comparison on byte
-func ByteComparator(a, b interface{}) int {
+func ByteComparator(a, b any) int {
 	aAsserted := a.(byte)
 	bAsserted := b.(byte)
 	switch {
@@ -222,7 +223,7 @@ func ByteComparator(a, b interface{}) int {
 }
 
 // RuneComparator provides a basic comparison on rune
-func RuneComparator(a, b interface{}) int {
+func RuneComparator(a, b any) int {
 	aAsserted := a.(rune)
 	bAsserted := b.(rune)
 	switch {
@@ -236,7 +237,7 @@ func RuneComparator(a, b interface{}) int {
 }
 
 // TimeComparator provides a basic comparison on time.Time
-func TimeComparator(a, b interface{}) int {
+func TimeComparator(a, b any) int {
 	aAsserted := a.(time.Time)
 	bAsserted := b.(time.Time)
 

--- a/utils/comparator_test.go
+++ b/utils/comparator_test.go
@@ -12,7 +12,7 @@ import (
 func TestIntComparator(t *testing.T) {
 
 	// i1,i2,expected
-	tests := [][]interface{}{
+	tests := [][]any{
 		{1, 1, 0},
 		{1, 2, -1},
 		{2, 1, 1},
@@ -34,7 +34,7 @@ func TestIntComparator(t *testing.T) {
 func TestStringComparator(t *testing.T) {
 
 	// s1,s2,expected
-	tests := [][]interface{}{
+	tests := [][]any{
 		{"a", "a", 0},
 		{"a", "b", -1},
 		{"b", "a", 1},
@@ -59,7 +59,7 @@ func TestTimeComparator(t *testing.T) {
 	now := time.Now()
 
 	// i1,i2,expected
-	tests := [][]interface{}{
+	tests := [][]any{
 		{now, now, 0},
 		{now.Add(24 * 7 * 2 * time.Hour), now, 1},
 		{now, now.Add(24 * 7 * 2 * time.Hour), -1},
@@ -81,7 +81,7 @@ func TestCustomComparator(t *testing.T) {
 		name string
 	}
 
-	byID := func(a, b interface{}) int {
+	byID := func(a, b any) int {
 		c1 := a.(Custom)
 		c2 := b.(Custom)
 		switch {
@@ -95,7 +95,7 @@ func TestCustomComparator(t *testing.T) {
 	}
 
 	// o1,o2,expected
-	tests := [][]interface{}{
+	tests := [][]any{
 		{Custom{1, "a"}, Custom{1, "a"}, 0},
 		{Custom{1, "a"}, Custom{2, "b"}, -1},
 		{Custom{2, "b"}, Custom{1, "a"}, 1},
@@ -112,7 +112,7 @@ func TestCustomComparator(t *testing.T) {
 }
 
 func TestInt8ComparatorComparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{int8(1), int8(1), 0},
 		{int8(0), int8(1), -1},
 		{int8(1), int8(0), 1},
@@ -127,7 +127,7 @@ func TestInt8ComparatorComparator(t *testing.T) {
 }
 
 func TestInt16Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{int16(1), int16(1), 0},
 		{int16(0), int16(1), -1},
 		{int16(1), int16(0), 1},
@@ -142,7 +142,7 @@ func TestInt16Comparator(t *testing.T) {
 }
 
 func TestInt32Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{int32(1), int32(1), 0},
 		{int32(0), int32(1), -1},
 		{int32(1), int32(0), 1},
@@ -157,7 +157,7 @@ func TestInt32Comparator(t *testing.T) {
 }
 
 func TestInt64Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{int64(1), int64(1), 0},
 		{int64(0), int64(1), -1},
 		{int64(1), int64(0), 1},
@@ -172,7 +172,7 @@ func TestInt64Comparator(t *testing.T) {
 }
 
 func TestUIntComparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{uint(1), uint(1), 0},
 		{uint(0), uint(1), -1},
 		{uint(1), uint(0), 1},
@@ -187,7 +187,7 @@ func TestUIntComparator(t *testing.T) {
 }
 
 func TestUInt8Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{uint8(1), uint8(1), 0},
 		{uint8(0), uint8(1), -1},
 		{uint8(1), uint8(0), 1},
@@ -202,7 +202,7 @@ func TestUInt8Comparator(t *testing.T) {
 }
 
 func TestUInt16Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{uint16(1), uint16(1), 0},
 		{uint16(0), uint16(1), -1},
 		{uint16(1), uint16(0), 1},
@@ -217,7 +217,7 @@ func TestUInt16Comparator(t *testing.T) {
 }
 
 func TestUInt32Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{uint32(1), uint32(1), 0},
 		{uint32(0), uint32(1), -1},
 		{uint32(1), uint32(0), 1},
@@ -232,7 +232,7 @@ func TestUInt32Comparator(t *testing.T) {
 }
 
 func TestUInt64Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{uint64(1), uint64(1), 0},
 		{uint64(0), uint64(1), -1},
 		{uint64(1), uint64(0), 1},
@@ -247,7 +247,7 @@ func TestUInt64Comparator(t *testing.T) {
 }
 
 func TestFloat32Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{float32(1.1), float32(1.1), 0},
 		{float32(0.1), float32(1.1), -1},
 		{float32(1.1), float32(0.1), 1},
@@ -262,7 +262,7 @@ func TestFloat32Comparator(t *testing.T) {
 }
 
 func TestFloat64Comparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{float64(1.1), float64(1.1), 0},
 		{float64(0.1), float64(1.1), -1},
 		{float64(1.1), float64(0.1), 1},
@@ -277,7 +277,7 @@ func TestFloat64Comparator(t *testing.T) {
 }
 
 func TestByteComparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{byte(1), byte(1), 0},
 		{byte(0), byte(1), -1},
 		{byte(1), byte(0), 1},
@@ -292,7 +292,7 @@ func TestByteComparator(t *testing.T) {
 }
 
 func TestRuneComparator(t *testing.T) {
-	tests := [][]interface{}{
+	tests := [][]any{
 		{rune(1), rune(1), 0},
 		{rune(0), rune(1), -1},
 		{rune(1), rune(0), 1},

--- a/utils/sort.go
+++ b/utils/sort.go
@@ -9,12 +9,12 @@ import "sort"
 // Sort sorts values (in-place) with respect to the given comparator.
 //
 // Uses Go's sort (hybrid of quicksort for large and then insertion sort for smaller slices).
-func Sort(values []interface{}, comparator Comparator) {
+func Sort(values []any, comparator Comparator) {
 	sort.Sort(sortable{values, comparator})
 }
 
 type sortable struct {
-	values     []interface{}
+	values     []any
 	comparator Comparator
 }
 

--- a/utils/sort_test.go
+++ b/utils/sort_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSortInts(t *testing.T) {
-	ints := []interface{}{}
+	ints := []any{}
 	ints = append(ints, 4)
 	ints = append(ints, 1)
 	ints = append(ints, 2)
@@ -28,7 +28,7 @@ func TestSortInts(t *testing.T) {
 
 func TestSortStrings(t *testing.T) {
 
-	strings := []interface{}{}
+	strings := []any{}
 	strings = append(strings, "d")
 	strings = append(strings, "a")
 	strings = append(strings, "b")
@@ -49,7 +49,7 @@ func TestSortStructs(t *testing.T) {
 		name string
 	}
 
-	byID := func(a, b interface{}) int {
+	byID := func(a, b any) int {
 		c1 := a.(User)
 		c2 := b.(User)
 		switch {
@@ -63,7 +63,7 @@ func TestSortStructs(t *testing.T) {
 	}
 
 	// o1,o2,expected
-	users := []interface{}{
+	users := []any{
 		User{4, "d"},
 		User{1, "a"},
 		User{3, "c"},
@@ -80,7 +80,7 @@ func TestSortStructs(t *testing.T) {
 }
 
 func TestSortRandom(t *testing.T) {
-	ints := []interface{}{}
+	ints := []any{}
 	for i := 0; i < 10000; i++ {
 		ints = append(ints, rand.Int())
 	}
@@ -94,7 +94,7 @@ func TestSortRandom(t *testing.T) {
 
 func BenchmarkGoSortRandom(b *testing.B) {
 	b.StopTimer()
-	ints := []interface{}{}
+	ints := []any{}
 	for i := 0; i < 100000; i++ {
 		ints = append(ints, rand.Int())
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ToString converts a value to string.
-func ToString(value interface{}) string {
+func ToString(value any) string {
 	switch value := value.(type) {
 	case string:
 		return value

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestToStringInts(t *testing.T) {
-	var value interface{}
+	var value any
 
 	value = int8(1)
 	if actualValue, expectedValue := ToString(value), "1"; actualValue != expectedValue {
@@ -39,7 +39,7 @@ func TestToStringInts(t *testing.T) {
 }
 
 func TestToStringUInts(t *testing.T) {
-	var value interface{}
+	var value any
 
 	value = uint8(1)
 	if actualValue, expectedValue := ToString(value), "1"; actualValue != expectedValue {
@@ -68,7 +68,7 @@ func TestToStringUInts(t *testing.T) {
 }
 
 func TestToStringFloats(t *testing.T) {
-	var value interface{}
+	var value any
 
 	value = float32(1.123456)
 	if actualValue, expectedValue := ToString(value), "1.123456"; !strings.HasPrefix(actualValue, expectedValue) {
@@ -81,7 +81,7 @@ func TestToStringFloats(t *testing.T) {
 }
 
 func TestToStringOther(t *testing.T) {
-	var value interface{}
+	var value any
 
 	value = "abc"
 	if actualValue, expectedValue := ToString(value), "abc"; actualValue != expectedValue {


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)