### PR TITLE
Replace equivalent fmt.Sprintf calls with strconv.Itoa

### DIFF
--- a/containers/containers_test.go
+++ b/containers/containers_test.go
@@ -8,9 +8,10 @@ package containers
 
 import (
 	"fmt"
-	"github.com/emirpasic/gods/utils"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 // For testing purposes

--- a/examples/avltree/avltree.go
+++ b/examples/avltree/avltree.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	avl "github.com/emirpasic/gods/trees/avltree"
 )
 

--- a/examples/btree/btree.go
+++ b/examples/btree/btree.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/trees/btree"
 )
 

--- a/examples/customcomparator/customcomparator.go
+++ b/examples/customcomparator/customcomparator.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/sets/treeset"
 )
 

--- a/examples/enumerablewithindex/enumerablewithindex.go
+++ b/examples/enumerablewithindex/enumerablewithindex.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/sets/treeset"
 )
 

--- a/examples/enumerablewithkey/enumerablewithkey.go
+++ b/examples/enumerablewithkey/enumerablewithkey.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/maps/treemap"
 )
 

--- a/examples/iteratorwithindex/iteratorwithindex.go
+++ b/examples/iteratorwithindex/iteratorwithindex.go
@@ -6,8 +6,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/emirpasic/gods/sets/treeset"
 	"strings"
+
+	"github.com/emirpasic/gods/sets/treeset"
 )
 
 // IteratorWithIndexExample to demonstrate basic usage of IteratorWithIndex

--- a/examples/iteratorwithkey/iteratorwithkey.go
+++ b/examples/iteratorwithkey/iteratorwithkey.go
@@ -6,8 +6,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/emirpasic/gods/maps/treemap"
 	"strings"
+
+	"github.com/emirpasic/gods/maps/treemap"
 )
 
 // IteratorWithKeyExample to demonstrate basic usage of IteratorWithKey

--- a/examples/redblacktree/redblacktree.go
+++ b/examples/redblacktree/redblacktree.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 )
 

--- a/examples/redblacktreeextended/redblacktreeextended.go
+++ b/examples/redblacktreeextended/redblacktreeextended.go
@@ -6,6 +6,7 @@ package redblacktreeextended
 
 import (
 	"fmt"
+
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 )
 

--- a/examples/serialization/serialization.go
+++ b/examples/serialization/serialization.go
@@ -2,6 +2,7 @@ package serialization
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/lists/arraylist"
 	"github.com/emirpasic/gods/maps/hashmap"
 )

--- a/lists/arraylist/arraylist_test.go
+++ b/lists/arraylist/arraylist_test.go
@@ -7,9 +7,10 @@ package arraylist
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/emirpasic/gods/utils"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 func TestListNew(t *testing.T) {

--- a/lists/arraylist/serialization.go
+++ b/lists/arraylist/serialization.go
@@ -6,6 +6,7 @@ package arraylist
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/lists/doublylinkedlist/serialization.go
+++ b/lists/doublylinkedlist/serialization.go
@@ -6,6 +6,7 @@ package doublylinkedlist
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/lists/singlylinkedlist/serialization.go
+++ b/lists/singlylinkedlist/serialization.go
@@ -6,6 +6,7 @@ package singlylinkedlist
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/maps/hashbidimap/hashbidimap.go
+++ b/maps/hashbidimap/hashbidimap.go
@@ -17,6 +17,7 @@ package hashbidimap
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/maps"
 	"github.com/emirpasic/gods/maps/hashmap"
 )

--- a/maps/hashbidimap/serialization.go
+++ b/maps/hashbidimap/serialization.go
@@ -6,6 +6,7 @@ package hashbidimap
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/maps/hashmap/hashmap.go
+++ b/maps/hashmap/hashmap.go
@@ -13,6 +13,7 @@ package hashmap
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/maps"
 )
 

--- a/maps/hashmap/serialization.go
+++ b/maps/hashmap/serialization.go
@@ -6,6 +6,7 @@ package hashmap
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 	"github.com/emirpasic/gods/utils"
 )

--- a/maps/linkedhashmap/linkedhashmap.go
+++ b/maps/linkedhashmap/linkedhashmap.go
@@ -13,9 +13,10 @@ package linkedhashmap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/doublylinkedlist"
 	"github.com/emirpasic/gods/maps"
-	"strings"
 )
 
 // Assert Map implementation

--- a/maps/linkedhashmap/serialization.go
+++ b/maps/linkedhashmap/serialization.go
@@ -7,6 +7,7 @@ package linkedhashmap
 import (
 	"bytes"
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 	"github.com/emirpasic/gods/utils"
 )

--- a/maps/treebidimap/serialization.go
+++ b/maps/treebidimap/serialization.go
@@ -6,6 +6,7 @@ package treebidimap
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 	"github.com/emirpasic/gods/utils"
 )

--- a/maps/treebidimap/treebidimap.go
+++ b/maps/treebidimap/treebidimap.go
@@ -19,10 +19,11 @@ package treebidimap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/maps"
 	"github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 // Assert Map implementation

--- a/maps/treebidimap/treebidimap_test.go
+++ b/maps/treebidimap/treebidimap_test.go
@@ -7,9 +7,10 @@ package treebidimap
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/emirpasic/gods/utils"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 func TestMapPut(t *testing.T) {

--- a/maps/treemap/treemap.go
+++ b/maps/treemap/treemap.go
@@ -13,10 +13,11 @@ package treemap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/maps"
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 // Assert Map implementation

--- a/maps/treemap/treemap_test.go
+++ b/maps/treemap/treemap_test.go
@@ -7,9 +7,10 @@ package treemap
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/emirpasic/gods/utils"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 func TestMapPut(t *testing.T) {

--- a/queues/circularbuffer/serialization.go
+++ b/queues/circularbuffer/serialization.go
@@ -6,6 +6,7 @@ package circularbuffer
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/queues/priorityqueue/priorityqueue.go
+++ b/queues/priorityqueue/priorityqueue.go
@@ -17,10 +17,11 @@ package priorityqueue
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/queues"
 	"github.com/emirpasic/gods/trees/binaryheap"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 // Assert Queue implementation

--- a/queues/priorityqueue/priorityqueue_test.go
+++ b/queues/priorityqueue/priorityqueue_test.go
@@ -7,10 +7,11 @@ package priorityqueue
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/emirpasic/gods/utils"
 	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 type Element struct {

--- a/sets/hashset/hashset.go
+++ b/sets/hashset/hashset.go
@@ -11,8 +11,9 @@ package hashset
 
 import (
 	"fmt"
-	"github.com/emirpasic/gods/sets"
 	"strings"
+
+	"github.com/emirpasic/gods/sets"
 )
 
 // Assert Set implementation

--- a/sets/hashset/serialization.go
+++ b/sets/hashset/serialization.go
@@ -6,6 +6,7 @@ package hashset
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/sets/linkedhashset/linkedhashset.go
+++ b/sets/linkedhashset/linkedhashset.go
@@ -15,9 +15,10 @@ package linkedhashset
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/doublylinkedlist"
 	"github.com/emirpasic/gods/sets"
-	"strings"
 )
 
 // Assert Set implementation

--- a/sets/linkedhashset/serialization.go
+++ b/sets/linkedhashset/serialization.go
@@ -6,6 +6,7 @@ package linkedhashset
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/sets/treeset/serialization.go
+++ b/sets/treeset/serialization.go
@@ -6,6 +6,7 @@ package treeset
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 )
 

--- a/sets/treeset/treeset.go
+++ b/sets/treeset/treeset.go
@@ -11,11 +11,12 @@ package treeset
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/emirpasic/gods/sets"
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
-	"reflect"
-	"strings"
 )
 
 // Assert Set implementation

--- a/stacks/arraystack/arraystack.go
+++ b/stacks/arraystack/arraystack.go
@@ -11,9 +11,10 @@ package arraystack
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/arraylist"
 	"github.com/emirpasic/gods/stacks"
-	"strings"
 )
 
 // Assert Stack implementation

--- a/stacks/linkedliststack/linkedliststack.go
+++ b/stacks/linkedliststack/linkedliststack.go
@@ -11,9 +11,10 @@ package linkedliststack
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/singlylinkedlist"
 	"github.com/emirpasic/gods/stacks"
-	"strings"
 )
 
 // Assert Stack implementation

--- a/trees/avltree/avltree.go
+++ b/trees/avltree/avltree.go
@@ -11,6 +11,7 @@ package avltree
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
 )

--- a/trees/avltree/avltree_test.go
+++ b/trees/avltree/avltree_test.go
@@ -6,9 +6,11 @@ package avltree
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/emirpasic/gods/utils"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 func TestAVLTreeGet(t *testing.T) {
@@ -182,14 +184,14 @@ func TestAVLTreeLeftAndRight(t *testing.T) {
 	tree.Put(1, "x") // overwrite
 	tree.Put(2, "b")
 
-	if actualValue, expectedValue := fmt.Sprintf("%d", tree.Left().Key), "1"; actualValue != expectedValue {
+	if actualValue, expectedValue := strconv.Itoa(tree.Left().Key), "1"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue, expectedValue := fmt.Sprintf("%s", tree.Left().Value), "x"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := fmt.Sprintf("%d", tree.Right().Key), "7"; actualValue != expectedValue {
+	if actualValue, expectedValue := strconv.Itoa(tree.Right().Key), "7"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue, expectedValue := fmt.Sprintf("%s", tree.Right().Value), "g"; actualValue != expectedValue {

--- a/trees/avltree/serialization.go
+++ b/trees/avltree/serialization.go
@@ -6,6 +6,7 @@ package avltree
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 	"github.com/emirpasic/gods/utils"
 )

--- a/trees/binaryheap/binaryheap.go
+++ b/trees/binaryheap/binaryheap.go
@@ -13,10 +13,11 @@ package binaryheap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/arraylist"
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 // Assert Tree implementation

--- a/trees/btree/btree.go
+++ b/trees/btree/btree.go
@@ -19,9 +19,10 @@ package btree
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 // Assert Tree implementation

--- a/trees/btree/serialization.go
+++ b/trees/btree/serialization.go
@@ -6,6 +6,7 @@ package btree
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 	"github.com/emirpasic/gods/utils"
 )

--- a/trees/redblacktree/redblacktree.go
+++ b/trees/redblacktree/redblacktree.go
@@ -13,6 +13,7 @@ package redblacktree
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
 )

--- a/trees/redblacktree/redblacktree_test.go
+++ b/trees/redblacktree/redblacktree_test.go
@@ -7,9 +7,11 @@ package redblacktree
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/emirpasic/gods/utils"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/utils"
 )
 
 func TestRedBlackTreeGet(t *testing.T) {
@@ -185,14 +187,14 @@ func TestRedBlackTreeLeftAndRight(t *testing.T) {
 	tree.Put(1, "x") // overwrite
 	tree.Put(2, "b")
 
-	if actualValue, expectedValue := fmt.Sprintf("%d", tree.Left().Key), "1"; actualValue != expectedValue {
+	if actualValue, expectedValue := strconv.Itoa(tree.Left().Key), "1"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue, expectedValue := fmt.Sprintf("%s", tree.Left().Value), "x"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 
-	if actualValue, expectedValue := fmt.Sprintf("%d", tree.Right().Key), "7"; actualValue != expectedValue {
+	if actualValue, expectedValue := strconv.Itoa(tree.Right().Key), "7"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 	if actualValue, expectedValue := fmt.Sprintf("%s", tree.Right().Value), "g"; actualValue != expectedValue {

--- a/trees/redblacktree/serialization.go
+++ b/trees/redblacktree/serialization.go
@@ -6,6 +6,7 @@ package redblacktree
 
 import (
 	"encoding/json"
+
 	"github.com/emirpasic/gods/containers"
 	"github.com/emirpasic/gods/utils"
 )


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls

[_Created by Sourcegraph batch change `kelli/comby-refactor`._](https://demo.sourcegraph.com/users/kelli/batch-changes/comby-refactor)